### PR TITLE
Messages are sorted by ordinal of severity

### DIFF
--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/converter/BpmnDiagramCheckResult.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/converter/BpmnDiagramCheckResult.java
@@ -11,9 +11,9 @@ public class BpmnDiagramCheckResult {
   }
 
   public enum Severity {
-    INFO,
     WARNING,
-    TASK
+    TASK,
+    INFO,
   }
 
   public static class BpmnElementCheckResult {

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/converter/MessageAppender.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/converter/MessageAppender.java
@@ -1,11 +1,10 @@
 package org.camunda.community.converter;
 
+import java.util.Comparator;
+import java.util.List;
 import org.camunda.bpm.model.xml.instance.DomDocument;
 import org.camunda.bpm.model.xml.instance.DomElement;
 import org.camunda.community.converter.BpmnDiagramCheckResult.BpmnElementCheckMessage;
-
-import java.util.Comparator;
-import java.util.List;
 
 public class MessageAppender {
   public void appendMessages(

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/converter/MessageAppender.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/converter/MessageAppender.java
@@ -1,15 +1,18 @@
 package org.camunda.community.converter;
 
-import java.util.List;
 import org.camunda.bpm.model.xml.instance.DomDocument;
 import org.camunda.bpm.model.xml.instance.DomElement;
 import org.camunda.community.converter.BpmnDiagramCheckResult.BpmnElementCheckMessage;
+
+import java.util.Comparator;
+import java.util.List;
 
 public class MessageAppender {
   public void appendMessages(
       DomElement element, List<BpmnElementCheckMessage> messages, boolean appendDocumentation) {
     if (!messages.isEmpty()) {
       DomElement extensionElements = getExtensionElements(element);
+      messages.sort(Comparator.comparingInt(message -> message.getSeverity().ordinal()));
       messages.forEach(
           message -> extensionElements.appendChild(createMessage(message, element.getDocument())));
       if (appendDocumentation) {


### PR DESCRIPTION
# Camunda Community Hub Pull Request Template

## Description
Currently, messages are appended to the result as they arrive from the visitors.

This can lead to bad information presentation, especially when multiple messages with different severities exist for each process element.

This enhancement sorts the messages by decreasing severity.

## Additional context
Presentation of the messages gets improved.

## Testing your changes
There is no direct testing as this fix completely relies on java- or jdk-native methods.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an existing open issue)
- [x] New feature (non-breaking change which adds functionality to an extension)
- [ ] Breaking change (fix or feature that would cause existing functionality of an extension to change)
- [ ] Documentation update (changes made to an existing piece of documentation)

## Checklist:
- [x] My code adheres to the syntax used by this extension.
- [ ] My pull request requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **Camunda Community Hub** documentation.
- [ ] I have read the **Pull Request Process** documentation.
- [ ] I have added or suggested tests to cover my changes suggested in this pull request.
- [x] All new and existing CI/CD tests passed.
- [ ] I will /assign myself this issue, and add the relevant [issue labels] to it if they are not automatically generated by Probot.
- [ ] I will tag @camunda-community-hub/devrel in a new comment on this issue if 30 days have passed since my pull request was opened and I have not received a response from the extension's maintainer.
