### PR TITLE
Feature: Converter CLI now supports Legacy file ending

### DIFF
--- a/backend-diagram-converter/cli/README.md
+++ b/backend-diagram-converter/cli/README.md
@@ -6,7 +6,7 @@
 
 The CLI tool can migrate a given diagram or all content inside a folder (plus subdirectories).
 
-All diagrams that should be converted need to have the `.bpmn` file ending.
+All diagrams that should be converted need to have the `.bpmn` or `.bpmn20.xml` file ending.
 
 The tool logs all results (either location of the new file or the exception the migration tool faced during migration). Diagrams that are already in C8 format will be logged as problem so that you know the converter got past them.
 

--- a/backend-diagram-converter/cli/src/main/java/org/camunda/community/converter/cli/ConvertCommand.java
+++ b/backend-diagram-converter/cli/src/main/java/org/camunda/community/converter/cli/ConvertCommand.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.OptionalInt;
 import java.util.concurrent.Callable;
@@ -24,6 +25,7 @@ import picocli.CommandLine.Parameters;
     versionProvider = MavenVersionProvider.class)
 public class ConvertCommand implements Callable<Integer> {
   private static final String DEFAULT_PREFIX = "converted-c8-";
+  private static final String[] FILE_ENDINGS = new String[] {"bpmn", "bpmn20.xml"};
   private final BpmnConverter converter = BpmnConverterFactory.getInstance().get();
 
   @Parameters(index = "0", description = "The file or directory to search for")
@@ -58,7 +60,7 @@ public class ConvertCommand implements Callable<Integer> {
     }
     Collection<File> files = new ArrayList<>();
     if (file.isDirectory()) {
-      files.addAll(FileUtils.listFiles(file, new String[] {"bpmn"}, !notRecursive));
+      files.addAll(FileUtils.listFiles(file, FILE_ENDINGS, !notRecursive));
     } else {
       if (isBpmnFile(file)) {
         files.add(file);
@@ -107,6 +109,6 @@ public class ConvertCommand implements Callable<Integer> {
   }
 
   private boolean isBpmnFile(File file) {
-    return file.getName().endsWith(".bpmn");
+    return Arrays.stream(FILE_ENDINGS).anyMatch(ending -> file.getName().endsWith(ending));
   }
 }

--- a/backend-diagram-converter/cli/src/main/java/org/camunda/community/converter/cli/ConvertCommand.java
+++ b/backend-diagram-converter/cli/src/main/java/org/camunda/community/converter/cli/ConvertCommand.java
@@ -28,7 +28,7 @@ import picocli.CommandLine.Parameters;
 public class ConvertCommand implements Callable<Integer> {
   private static final String DEFAULT_PREFIX = "converted-c8-";
   private static final String[] FILE_ENDINGS = new String[] {"bpmn", "bpmn20.xml"};
-  
+
   private final BpmnConverter converter;
 
   @Parameters(index = "0", description = "The file or directory to search for")

--- a/backend-diagram-converter/cli/src/test/java/org/camunda/community/converter/cli/ConvertCommandTest.java
+++ b/backend-diagram-converter/cli/src/test/java/org/camunda/community/converter/cli/ConvertCommandTest.java
@@ -30,6 +30,15 @@ public class ConvertCommandTest {
   }
 
   @Test
+  public void shouldConvertLegacy(@TempDir File tempDir) {
+    setupDir("c7.bpmn20.xml", tempDir);
+    ConvertCommand command = new ConvertCommand();
+    command.file = tempDir;
+    Integer call = command.call();
+    assertEquals(0, call);
+  }
+
+  @Test
   @Disabled
   // TODO enable as soon as bugfix for CLI is merged
   public void shouldNotConvert(@TempDir File tempDir) {

--- a/backend-diagram-converter/cli/src/test/resources/c7.bpmn20.xml
+++ b/backend-diagram-converter/cli/src/test/resources/c7.bpmn20.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1v7ktfp" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.5.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.18.0">
+  <bpmn:process id="Process_03159n1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_1650hrw</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1650hrw" sourceRef="StartEvent_1" targetRef="Activity_0l0rord" />
+    <bpmn:endEvent id="Event_00s2833" name="End">
+      <bpmn:incoming>Flow_15nypxy</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_15nypxy" sourceRef="Activity_0l0rord" targetRef="Event_00s2833" />
+    <bpmn:userTask id="Activity_0l0rord" name="User Task">
+      <bpmn:incoming>Flow_1650hrw</bpmn:incoming>
+      <bpmn:outgoing>Flow_15nypxy</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_03159n1">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="185" y="142" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_00s2833_di" bpmnElement="Event_00s2833">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="440" y="142" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_159im56_di" bpmnElement="Activity_0l0rord">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1650hrw_di" bpmnElement="Flow_1650hrw">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_15nypxy_di" bpmnElement="Flow_15nypxy">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Description
As of now, only files with `.bpmn` ending were recognized as BPMN Files.

In fact, there was a time when BPMN Files had a `.bpmn20.xml` ending. 

We must not ignore this.

## Additional context
Closes #74 

## Testing your changes
There was a test added to check whether the ending would be recognized
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an existing open issue)
- [x] New feature (non-breaking change which adds functionality to an extension)
- [ ] Breaking change (fix or feature that would cause existing functionality of an extension to change)
- [x] Documentation update (changes made to an existing piece of documentation)

## Checklist:
<!--- Please review the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code adheres to the syntax used by this extension.
- [ ] My pull request requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **Camunda Community Hub** documentation.
- [x] I have read the **Pull Request Process** documentation.
- [x] I have added or suggested tests to cover my changes suggested in this pull request.
- [x] All new and existing CI/CD tests passed.
- [x] I will /assign myself this issue, and add the relevant [issue labels] to it if they are not automatically generated by Probot.
- [x] I will tag @camunda-community-hub/devrel in a new comment on this issue if 30 days have passed since my pull request was opened and I have not received a response from the extension's maintainer.
