### PR TITLE
Feature: Converter webapp exports Check results as CSV

### DIFF
--- a/backend-diagram-converter/webapp/README.md
+++ b/backend-diagram-converter/webapp/README.md
@@ -16,9 +16,9 @@ The frontend is self-explanatory. You upload .bpmn Files and then click either *
 
 The API offers 2 methods:
 
-`POST /check`: Requires the usage of `FormData`. The formdata needs to consist of fields `files` which are the .bpmn Files. It will return:
+`POST /check`: Requires the usage of `FormData`. The formdata needs to consist of fields `files` which are the .bpmn Files. In the `Accept` header, you can either set `application/json` or `text/csv`. It will return:
 
-`200`: Everything fine. The body contains a list of [check results](./../core/src/main/java/org/camunda/community/converter/BpmnDiagramCheckResult.java).
+`200`: Everything fine. The body contains a list of [check results](./../core/src/main/java/org/camunda/community/converter/BpmnDiagramCheckResult.java), either in `application/json` format or flattened as `text/csv`.
 
 `POST /convert`: Requires the usage of `FormData`. The formdata needs to consist of fields `files` which are the .bpmn Files plus a field `appendDocumentation` which is a boolean and controls whether the messages are also appended to the documentation section of each BPMN element. It will return:
 

--- a/backend-diagram-converter/webapp/pom.xml
+++ b/backend-diagram-converter/webapp/pom.xml
@@ -19,7 +19,10 @@
     <dependency>
       <groupId>com.slack.api</groupId>
       <artifactId>slack-api-client</artifactId>
-      <version>1.27.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.opencsv</groupId>
+      <artifactId>opencsv</artifactId>
     </dependency>
     <dependency>
       <groupId>org.camunda.community.migration</groupId>

--- a/backend-diagram-converter/webapp/pom.xml
+++ b/backend-diagram-converter/webapp/pom.xml
@@ -38,6 +38,11 @@
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/backend-diagram-converter/webapp/src/main/java/org/camunda/community/converter/webapp/ConverterController.java
+++ b/backend-diagram-converter/webapp/src/main/java/org/camunda/community/converter/webapp/ConverterController.java
@@ -1,17 +1,5 @@
 package org.camunda.community.converter.webapp;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.StringWriter;
-import java.util.AbstractMap.SimpleEntry;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
 import org.camunda.bpm.model.bpmn.Bpmn;
 import org.camunda.bpm.model.bpmn.BpmnModelInstance;
 import org.camunda.community.converter.BpmnDiagramCheckResult;
@@ -26,6 +14,19 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 @RestController
 public class ConverterController {
@@ -65,6 +66,7 @@ public class ConverterController {
                 })
             .collect(Collectors.toList());
     if (contentType == null
+        || contentType.length == 0
         || Arrays.asList(contentType).contains(MediaType.APPLICATION_JSON_VALUE)) {
       return ResponseEntity.ok(results);
     }

--- a/backend-diagram-converter/webapp/src/main/java/org/camunda/community/converter/webapp/ConverterController.java
+++ b/backend-diagram-converter/webapp/src/main/java/org/camunda/community/converter/webapp/ConverterController.java
@@ -1,5 +1,17 @@
 package org.camunda.community.converter.webapp;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 import org.camunda.bpm.model.bpmn.Bpmn;
 import org.camunda.bpm.model.bpmn.BpmnModelInstance;
 import org.camunda.community.converter.BpmnDiagramCheckResult;
@@ -14,19 +26,6 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.StringWriter;
-import java.util.AbstractMap.SimpleEntry;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
 
 @RestController
 public class ConverterController {

--- a/backend-diagram-converter/webapp/src/main/java/org/camunda/community/converter/webapp/ConverterController.java
+++ b/backend-diagram-converter/webapp/src/main/java/org/camunda/community/converter/webapp/ConverterController.java
@@ -3,6 +3,7 @@ package org.camunda.community.converter.webapp;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.StringWriter;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -21,6 +22,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -28,16 +30,23 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 public class ConverterController {
   private final BpmnConverterService bpmnConverter;
+  private final CsvWriterService csvWriterService;
 
   @Autowired
-  public ConverterController(BpmnConverterService bpmnConverter) {
+  public ConverterController(
+      BpmnConverterService bpmnConverter, CsvWriterService csvWriterService) {
     this.bpmnConverter = bpmnConverter;
+    this.csvWriterService = csvWriterService;
   }
 
-  @PostMapping("/check")
+  @PostMapping(
+      value = "/check",
+      produces = {MediaType.APPLICATION_JSON_VALUE, "text/csv"},
+      consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
   public ResponseEntity<?> check(
       @RequestParam("files") MultipartFile[] bpmnFiles,
-      @RequestParam(value = "adapterJobType", required = false) String adapterJobType) {
+      @RequestParam(value = "adapterJobType", required = false) String adapterJobType,
+      @RequestHeader(HttpHeaders.ACCEPT) String contentType) {
     List<BpmnDiagramCheckResult> results =
         Arrays.stream(bpmnFiles)
             .map(
@@ -55,10 +64,26 @@ public class ConverterController {
                   }
                 })
             .collect(Collectors.toList());
-    return ResponseEntity.ok(results);
+    if (contentType == null || contentType.equals(MediaType.APPLICATION_JSON_VALUE)) {
+      return ResponseEntity.ok(results);
+    }
+    if (contentType.equals("text/csv")) {
+      StringWriter sw = new StringWriter();
+      csvWriterService.writeCsvFile(results, sw);
+      Resource file = new ByteArrayResource(sw.toString().getBytes());
+      return ResponseEntity.ok()
+          .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"conversionResult.csv\"")
+          .contentType(MediaType.APPLICATION_OCTET_STREAM)
+          .body(file);
+    } else {
+      return ResponseEntity.badRequest().build();
+    }
   }
 
-  @PostMapping("/convert")
+  @PostMapping(
+      value = "/convert",
+      produces = {MediaType.APPLICATION_OCTET_STREAM_VALUE},
+      consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
   public ResponseEntity<?> getFile(
       @RequestParam("files") MultipartFile[] bpmnFiles,
       @RequestParam("appendDocumentation") boolean appendDocumentation,

--- a/backend-diagram-converter/webapp/src/main/java/org/camunda/community/converter/webapp/ConverterController.java
+++ b/backend-diagram-converter/webapp/src/main/java/org/camunda/community/converter/webapp/ConverterController.java
@@ -46,7 +46,7 @@ public class ConverterController {
   public ResponseEntity<?> check(
       @RequestParam("files") MultipartFile[] bpmnFiles,
       @RequestParam(value = "adapterJobType", required = false) String adapterJobType,
-      @RequestHeader(HttpHeaders.ACCEPT) String contentType) {
+      @RequestHeader(HttpHeaders.ACCEPT) String[] contentType) {
     List<BpmnDiagramCheckResult> results =
         Arrays.stream(bpmnFiles)
             .map(
@@ -64,10 +64,11 @@ public class ConverterController {
                   }
                 })
             .collect(Collectors.toList());
-    if (contentType == null || contentType.equals(MediaType.APPLICATION_JSON_VALUE)) {
+    if (contentType == null
+        || Arrays.asList(contentType).contains(MediaType.APPLICATION_JSON_VALUE)) {
       return ResponseEntity.ok(results);
     }
-    if (contentType.equals("text/csv")) {
+    if (Arrays.asList(contentType).contains("text/csv")) {
       StringWriter sw = new StringWriter();
       csvWriterService.writeCsvFile(results, sw);
       Resource file = new ByteArrayResource(sw.toString().getBytes());

--- a/backend-diagram-converter/webapp/src/main/java/org/camunda/community/converter/webapp/CsvWriterService.java
+++ b/backend-diagram-converter/webapp/src/main/java/org/camunda/community/converter/webapp/CsvWriterService.java
@@ -1,0 +1,50 @@
+package org.camunda.community.converter.webapp;
+
+import com.opencsv.CSVWriterBuilder;
+import com.opencsv.ICSVWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.camunda.community.converter.BpmnDiagramCheckResult;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CsvWriterService {
+  public void writeCsvFile(List<BpmnDiagramCheckResult> results, Writer writer) {
+    try (ICSVWriter csvWriter = new CSVWriterBuilder(writer).withSeparator(';').build()) {
+      csvWriter.writeNext(createHeaders());
+      csvWriter.writeAll(createLines(results));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private String[] createHeaders() {
+    return new String[] {
+      "filename", "elementName", "elementId", "elementType", "severity", "message", "link"
+    };
+  }
+
+  private List<String[]> createLines(List<BpmnDiagramCheckResult> results) {
+    return results.stream()
+        .flatMap(
+            diagramCheckResult ->
+                diagramCheckResult.getResults().stream()
+                    .flatMap(
+                        elementCheckResult ->
+                            elementCheckResult.getMessages().stream()
+                                .map(
+                                    message ->
+                                        new String[] {
+                                          diagramCheckResult.getFilename(),
+                                          elementCheckResult.getElementName(),
+                                          elementCheckResult.getElementId(),
+                                          elementCheckResult.getElementType(),
+                                          message.getSeverity().name(),
+                                          message.getMessage(),
+                                          message.getLink()
+                                        })))
+        .collect(Collectors.toList());
+  }
+}

--- a/backend-diagram-converter/webapp/src/main/resources/static/index.html
+++ b/backend-diagram-converter/webapp/src/main/resources/static/index.html
@@ -25,7 +25,7 @@
             test any converted diagram.</p>
     </div>
     <div class="row">
-        <div class="mb-3" id="file-select">
+        <div class="mb-3">
             <label for="formFile" class="form-label">Camunda 7 BPMN files</label>
             <input class="form-control" type="file" id="formFile" multiple>
         </div>
@@ -38,6 +38,7 @@
         <div class="mb-3">
             <button type="button" class="btn btn-primary" id="check">Check</button>
             <button type="button" class="btn btn-primary" id="convert">Convert and download</button>
+            <button type="button" class="btn btn-primary" id="downloadCsv">Download Checklist as CSV</button>
         </div>
     </div>
     <div class="row">
@@ -85,6 +86,7 @@
 <script>
     const check = document.getElementById("check");
     const convert = document.getElementById("convert");
+    const downloadCsv = document.getElementById("downloadCsv");
 
     const fileUpload = document.getElementById("formFile");
     const appendDocumentation = document.getElementById("appendDocumentation");
@@ -98,7 +100,6 @@
         "INFO": "text-bg-info",
         "TASK": "text-bg-secondary"
     }
-
 
     const el = (tagName, attributes, children) => {
         const element = document.createElement(tagName);
@@ -141,12 +142,24 @@
     }
 
     const createFormattedResultForFile = file => {
+        console.log(file);
         return el("div", {className: "card mb-3"}, [
             el("div", {className: "card-header"}, [file.filename]),
             el("ul", {className: "list-group list-group-flush"}, file.results.map(createFormattedResult).filter(e => e !== undefined))
         ]);
+
     }
 
+    const downloadResponse = async response => {
+        const contentDisposition = response.headers.get("Content-Disposition");
+        const targetFileName = contentDisposition.substring(contentDisposition.indexOf("\"") + 1, contentDisposition.lastIndexOf("\""));
+        response.blob().then(data => {
+            const a = document.createElement("a");
+            a.href = window.URL.createObjectURL(data);
+            a.download = targetFileName;
+            a.click();
+        });
+    };
 
     check.addEventListener("click", async () => {
         const formData = await createFormData();
@@ -166,6 +179,20 @@
         });
     });
 
+    downloadCsv.addEventListener("click", async () => {
+        const formData = await createFormData();
+        if (!formData) {
+            return;
+        }
+        fetch("/check", {
+            body: formData,
+            method: "POST",
+            headers: {
+                "Accept": "text/csv"
+            }
+        }).then(downloadResponse);
+    });
+
     convert.addEventListener("click", async () => {
         const formData = await createFormData();
         if (!formData) {
@@ -174,16 +201,7 @@
         fetch("/convert", {
             body: formData,
             method: "POST"
-        }).then(response => {
-            const contentDisposition = response.headers.get("Content-Disposition");
-            const targetFileName = contentDisposition.substring(contentDisposition.indexOf("\"") + 1, contentDisposition.lastIndexOf("\""));
-            response.blob().then(data => {
-                const a = document.createElement("a");
-                a.href = window.URL.createObjectURL(data);
-                a.download = targetFileName;
-                a.click();
-            })
-        });
+        }).then(downloadResponse);
     });
 </script>
 </body>

--- a/backend-diagram-converter/webapp/src/main/resources/static/index.html
+++ b/backend-diagram-converter/webapp/src/main/resources/static/index.html
@@ -168,7 +168,10 @@
         }
         fetch("/check", {
             body: formData,
-            method: "POST"
+            method: "POST",
+            headers: {
+            	  "Accept": "application/json"
+            }
         }).then(response => {
             response.json().then(json => {
                 checkContainer.innerHTML = JSON.stringify(json, null, 2);

--- a/backend-diagram-converter/webapp/src/test/java/org/camunda/community/converter/webapp/ConverterControllerTest.java
+++ b/backend-diagram-converter/webapp/src/test/java/org/camunda/community/converter/webapp/ConverterControllerTest.java
@@ -1,0 +1,89 @@
+package org.camunda.community.converter.webapp;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.opencsv.CSVParserBuilder;
+import com.opencsv.CSVReader;
+import com.opencsv.CSVReaderBuilder;
+import com.opencsv.exceptions.CsvException;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.restassured.RestAssured;
+import io.restassured.common.mapper.TypeRef;
+import io.restassured.http.ContentType;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.zip.ZipInputStream;
+import org.camunda.bpm.model.xml.instance.DomElement;
+import org.camunda.community.converter.BpmnDiagramCheckResult;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+
+@SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
+public class ConverterControllerTest {
+
+  @Test
+  void shouldReturnCheckResult() throws URISyntaxException {
+    List<BpmnDiagramCheckResult> checkResult =
+        RestAssured.given()
+            .contentType(ContentType.MULTIPART)
+            .multiPart(
+                "files", new File(getClass().getClassLoader().getResource("example.bpmn").toURI()))
+            .accept(ContentType.JSON)
+            .post("http://localhost:8080/check")
+            .getBody()
+            .as(new TypeRef<List<BpmnDiagramCheckResult>>() {});
+    assertThat(checkResult).hasSize(1);
+    assertThat(checkResult.get(0))
+        .matches(
+            result -> result.getFilename().equals("example.bpmn"), "Filename is set correctly");
+    assertThat(checkResult.get(0).getResults()).isNotEmpty();
+  }
+
+  @Test
+  void shouldReturnCsv() throws URISyntaxException, IOException {
+    String body =
+        RestAssured.given()
+            .contentType(ContentType.MULTIPART)
+            .multiPart(
+                "files", new File(getClass().getClassLoader().getResource("example.bpmn").toURI()))
+            .accept("text/csv")
+            .post("http://localhost:8080/check")
+            .getBody()
+            .print();
+    try (CSVReader reader =
+        new CSVReaderBuilder(new StringReader(body))
+            .withCSVParser(new CSVParserBuilder().withSeparator(';').build())
+            .build()) {
+      List<String[]> all = reader.readAll();
+      assertThat(all).hasSize(2);
+    } catch (CsvException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  void shouldReturnZip() throws IOException, URISyntaxException {
+    byte[] zip =
+        RestAssured.given()
+            .contentType(ContentType.MULTIPART)
+            .multiPart(
+                "files", new File(getClass().getClassLoader().getResource("example.bpmn").toURI()))
+            .accept("text/csv")
+            .post("http://localhost:8080/convert")
+            .getBody()
+            .asByteArray();
+    try (ZipInputStream inputStream = new ZipInputStream(new ByteArrayInputStream(zip))) {
+      while (inputStream.getNextEntry() != null) {
+        BpmnModelInstance bpmnModelInstance = Bpmn.readModelFromStream(inputStream);
+        DomElement process = bpmnModelInstance.getDocument().getElementById("Process_11j5dku");
+        assertThat(process).isNotNull();
+      }
+    }
+  }
+}

--- a/backend-diagram-converter/webapp/src/test/java/org/camunda/community/converter/webapp/CsvWriterServiceTest.java
+++ b/backend-diagram-converter/webapp/src/test/java/org/camunda/community/converter/webapp/CsvWriterServiceTest.java
@@ -1,0 +1,83 @@
+package org.camunda.community.converter.webapp;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.opencsv.CSVParserBuilder;
+import com.opencsv.CSVReader;
+import com.opencsv.CSVReaderBuilder;
+import com.opencsv.exceptions.CsvException;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+import org.camunda.community.converter.BpmnDiagramCheckResult;
+import org.camunda.community.converter.BpmnDiagramCheckResult.BpmnElementCheckMessage;
+import org.camunda.community.converter.BpmnDiagramCheckResult.BpmnElementCheckResult;
+import org.camunda.community.converter.BpmnDiagramCheckResult.Severity;
+import org.junit.jupiter.api.Test;
+
+public class CsvWriterServiceTest {
+  private static final String FILENAME = "mock-process.bpmn";
+  private static final String LINK = "https://www.example.com";
+  private static final String MESSAGE = "Test message";
+  private static final String ELEMENT_ID = "abc.123";
+  private static final String ELEMENT_NAME = "Example;Name";
+  private static final String ELEMENT_TYPE = "userTask";
+  private static final Severity SEVERITY = Severity.TASK;
+  private static final CsvWriterService SERVICE = new CsvWriterService();
+
+  @Test
+  public void shouldCreateValidCsv() {
+    StringWriter writer = new StringWriter();
+    List<BpmnDiagramCheckResult> results = mockResults();
+    SERVICE.writeCsvFile(results, writer);
+
+    StringReader reader = new StringReader(writer.toString());
+    try (CSVReader csvReader =
+        new CSVReaderBuilder(reader)
+            .withCSVParser(new CSVParserBuilder().withSeparator(';').build())
+            .build()) {
+      List<String[]> lines = csvReader.readAll();
+      assertThat(lines).hasSize(2);
+      assertThat(lines.get(0))
+          .containsExactly(
+              "filename", "elementName", "elementId", "elementType", "severity", "message", "link");
+      assertThat(lines.get(1))
+          .containsExactly(
+              FILENAME, ELEMENT_NAME, ELEMENT_ID, ELEMENT_TYPE, SEVERITY.name(), MESSAGE, LINK);
+    } catch (IOException | CsvException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private List<BpmnDiagramCheckResult> mockResults() {
+    List<BpmnDiagramCheckResult> results = new ArrayList<>();
+    results.add(mockDiagramResult());
+    return results;
+  }
+
+  private BpmnDiagramCheckResult mockDiagramResult() {
+    BpmnDiagramCheckResult result = new BpmnDiagramCheckResult();
+    result.setFilename(FILENAME);
+    result.getResults().add(mockElementResult());
+    return result;
+  }
+
+  private BpmnElementCheckResult mockElementResult() {
+    BpmnElementCheckResult result = new BpmnElementCheckResult();
+    result.setElementId(ELEMENT_ID);
+    result.setElementName(ELEMENT_NAME);
+    result.setElementType(ELEMENT_TYPE);
+    result.getMessages().add(mockMessage());
+    return result;
+  }
+
+  private BpmnElementCheckMessage mockMessage() {
+    BpmnElementCheckMessage message = new BpmnElementCheckMessage();
+    message.setSeverity(SEVERITY);
+    message.setMessage(MESSAGE);
+    message.setLink(LINK);
+    return message;
+  }
+}

--- a/backend-diagram-converter/webapp/src/test/resources/example.bpmn
+++ b/backend-diagram-converter/webapp/src/test/resources/example.bpmn
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1hvywq4" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.5.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.18.0">
+  <bpmn:process id="Process_11j5dku" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_02fdbbu</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_02fdbbu" sourceRef="StartEvent_1" targetRef="Activity_05chp7l" />
+    <bpmn:endEvent id="Event_1nulbva">
+      <bpmn:incoming>Flow_0lnqpef</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0lnqpef" sourceRef="Activity_05chp7l" targetRef="Event_1nulbva" />
+    <bpmn:serviceTask id="Activity_05chp7l" camunda:class="com.example.MyDelegate">
+      <bpmn:incoming>Flow_02fdbbu</bpmn:incoming>
+      <bpmn:outgoing>Flow_0lnqpef</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_11j5dku">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1nulbva_di" bpmnElement="Event_1nulbva">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1feptow_di" bpmnElement="Activity_05chp7l">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_02fdbbu_di" bpmnElement="Flow_02fdbbu">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0lnqpef_di" bpmnElement="Flow_0lnqpef">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,8 @@
     <version.spring-boot>2.7.5</version.spring-boot>
     <version.picocli>4.7.0</version.picocli>
     <version.commons-io>2.11.0</version.commons-io>
+    <version.slack-api-client>1.27.1</version.slack-api-client>
+    <version.opencsv>5.7.1</version.opencsv>
 
     <plugin.version.function-maven-plugin>0.10.1</plugin.version.function-maven-plugin>
     <plugin.version.maven-enforcer-plugin>3.1.0</plugin.version.maven-enforcer-plugin>
@@ -96,6 +98,16 @@
         <groupId>org.jsoup</groupId>
         <artifactId>jsoup</artifactId>
         <version>${version.jsoup}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.slack.api</groupId>
+        <artifactId>slack-api-client</artifactId>
+        <version>${version.slack-api-client}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.opencsv</groupId>
+        <artifactId>opencsv</artifactId>
+        <version>${version.opencsv}</version>
       </dependency>
       <dependency>
         <groupId>org.camunda.community.migration</groupId>


### PR DESCRIPTION
## Description
Currently, the check result is returned as json by the API and displayed in the webapp.

This might not be useful for creating assets to structure a migration project.

For simplicity, a CSV export containing all data from the check result should be sufficient.

## Additional context
Closes #58 

## Testing your changes
There is a test for the `CsvWriterService` in place as well as for the RestController

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an existing open issue)
- [x] New feature (non-breaking change which adds functionality to an extension)
- [ ] Breaking change (fix or feature that would cause existing functionality of an extension to change)
- [ ] Documentation update (changes made to an existing piece of documentation)

## Checklist:
- [x] My code adheres to the syntax used by this extension.
- [x] My pull request requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **Camunda Community Hub** documentation.
- [x] I have read the **Pull Request Process** documentation.
- [x] I have added or suggested tests to cover my changes suggested in this pull request.
- [x] All new and existing CI/CD tests passed.
- [x] I will /assign myself this issue, and add the relevant [issue labels] to it if they are not automatically generated by Probot.
- [x] I will tag @camunda-community-hub/devrel in a new comment on this issue if 30 days have passed since my pull request was opened and I have not received a response from the extension's maintainer.
