### PR TITLE
Feature: Event references

### DIFF
--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/BpmnConverter.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/BpmnConverter.java
@@ -7,6 +7,7 @@ import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
@@ -74,17 +75,38 @@ public class BpmnConverter {
                             attribute -> element.removeAttribute(namespaceUri, attribute))));
     LOG.info("Done remove of old elements");
     LOG.info("Start conversion");
-    MessageAppender messageAppender = new MessageAppender();
+    ConversionElementAppender conversionElementAppender = new ConversionElementAppender();
     context
         .getConvertibles()
         .forEach(
             (element, convertible) -> {
               List<BpmnElementCheckMessage> messages = getMessages(element, result);
-              messageAppender.appendMessages(element, messages, appendDocumentation);
+              List<String> references = getReferences(element, result);
+              List<String> referencedBys = getReferencedBys(element, result);
+              conversionElementAppender.appendMessages(element, messages);
+              conversionElementAppender.appendReferences(element, references);
+              conversionElementAppender.appendReferencedBy(element, referencedBys);
+              if (appendDocumentation) {
+                conversionElementAppender.appendDocumentation(
+                    element, collectMessages(result, messages, references));
+              }
               conversions.forEach(conversion -> conversion.convert(element, convertible, messages));
             });
     LOG.info("Done with conversion");
     return result;
+  }
+
+  private List<BpmnElementCheckMessage> collectMessages(
+      BpmnDiagramCheckResult result,
+      List<BpmnElementCheckMessage> messages,
+      List<String> references) {
+    List<BpmnElementCheckMessage> r = new ArrayList<>();
+    r.addAll(messages);
+    r.addAll(
+        references.stream()
+            .flatMap(reference -> getMessages(reference, result).stream())
+            .collect(Collectors.toList()));
+    return r;
   }
 
   private List<BpmnElementCheckMessage> getMessages(
@@ -92,6 +114,31 @@ public class BpmnConverter {
     return result.getResults().stream()
         .filter(r -> r.getElementId().equals(element.getAttribute("id")))
         .map(BpmnElementCheckResult::getMessages)
+        .findFirst()
+        .orElseGet(ArrayList::new);
+  }
+
+  private List<BpmnElementCheckMessage> getMessages(
+      String elementId, BpmnDiagramCheckResult result) {
+    return result.getResults().stream()
+        .filter(r -> r.getElementId().equals(elementId))
+        .map(BpmnElementCheckResult::getMessages)
+        .findFirst()
+        .orElseGet(ArrayList::new);
+  }
+
+  private List<String> getReferences(DomElement element, BpmnDiagramCheckResult result) {
+    return result.getResults().stream()
+        .filter(r -> r.getElementId().equals(element.getAttribute("id")))
+        .map(BpmnElementCheckResult::getReferences)
+        .findFirst()
+        .orElseGet(ArrayList::new);
+  }
+
+  private List<String> getReferencedBys(DomElement element, BpmnDiagramCheckResult result) {
+    return result.getResults().stream()
+        .filter(r -> r.getElementId().equals(element.getAttribute("id")))
+        .map(BpmnElementCheckResult::getReferencedBy)
         .findFirst()
         .orElseGet(ArrayList::new);
   }

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/BpmnConverter.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/BpmnConverter.java
@@ -100,19 +100,21 @@ public class BpmnConverter {
       BpmnDiagramCheckResult result,
       List<BpmnElementCheckMessage> messages,
       List<String> references) {
-    List<BpmnElementCheckMessage> r = new ArrayList<>();
-    r.addAll(messages);
-    r.addAll(
+    List<BpmnElementCheckMessage> collectedMessages = new ArrayList<>();
+    collectedMessages.addAll(messages);
+    collectedMessages.addAll(
         references.stream()
             .flatMap(reference -> getMessages(reference, result).stream())
             .collect(Collectors.toList()));
-    return r;
+    return collectedMessages;
   }
 
   private List<BpmnElementCheckMessage> getMessages(
       DomElement element, BpmnDiagramCheckResult result) {
     return result.getResults().stream()
-        .filter(r -> r.getElementId().equals(element.getAttribute("id")))
+        .filter(
+            elementCheckResult ->
+                elementCheckResult.getElementId().equals(element.getAttribute("id")))
         .map(BpmnElementCheckResult::getMessages)
         .findFirst()
         .orElseGet(ArrayList::new);
@@ -121,7 +123,7 @@ public class BpmnConverter {
   private List<BpmnElementCheckMessage> getMessages(
       String elementId, BpmnDiagramCheckResult result) {
     return result.getResults().stream()
-        .filter(r -> r.getElementId().equals(elementId))
+        .filter(elementCheckResult -> elementCheckResult.getElementId().equals(elementId))
         .map(BpmnElementCheckResult::getMessages)
         .findFirst()
         .orElseGet(ArrayList::new);
@@ -129,7 +131,9 @@ public class BpmnConverter {
 
   private List<String> getReferences(DomElement element, BpmnDiagramCheckResult result) {
     return result.getResults().stream()
-        .filter(r -> r.getElementId().equals(element.getAttribute("id")))
+        .filter(
+            elementCheckResult ->
+                elementCheckResult.getElementId().equals(element.getAttribute("id")))
         .map(BpmnElementCheckResult::getReferences)
         .findFirst()
         .orElseGet(ArrayList::new);
@@ -137,7 +141,9 @@ public class BpmnConverter {
 
   private List<String> getReferencedBys(DomElement element, BpmnDiagramCheckResult result) {
     return result.getResults().stream()
-        .filter(r -> r.getElementId().equals(element.getAttribute("id")))
+        .filter(
+            elementCheckResult ->
+                elementCheckResult.getElementId().equals(element.getAttribute("id")))
         .map(BpmnElementCheckResult::getReferencedBy)
         .findFirst()
         .orElseGet(ArrayList::new);

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/BpmnDiagramCheckContext.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/BpmnDiagramCheckContext.java
@@ -2,9 +2,11 @@ package org.camunda.community.migration.converter;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.camunda.bpm.model.xml.instance.DomElement;
+import org.camunda.community.migration.converter.BpmnDiagramCheckResult.BpmnElementCheckResult;
 import org.camunda.community.migration.converter.convertible.Convertible;
 
 public class BpmnDiagramCheckContext {
@@ -13,6 +15,7 @@ public class BpmnDiagramCheckContext {
   private final Map<DomElement, Map<String, Set<String>>> attributesToRemove = new HashMap<>();
 
   private final Map<DomElement, Convertible> convertibles = new HashMap<>();
+  private final Map<String, List<BpmnElementCheckResult>> referencesToCreate = new HashMap<>();
 
   public Map<DomElement, Convertible> getConvertibles() {
     return convertibles;
@@ -38,5 +41,9 @@ public class BpmnDiagramCheckContext {
       throw new IllegalStateException("There must only be one convertible per element!");
     }
     convertibles.put(element, convertible);
+  }
+
+  public Map<String, List<BpmnElementCheckResult>> getReferencesToCreate() {
+    return referencesToCreate;
   }
 }

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/BpmnDiagramCheckResult.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/BpmnDiagramCheckResult.java
@@ -34,6 +34,8 @@ public class BpmnDiagramCheckResult {
 
   public static class BpmnElementCheckResult {
     private final List<BpmnElementCheckMessage> messages = new ArrayList<>();
+    private final List<String> references = new ArrayList<>();
+    private final List<String> referencedBy = new ArrayList<>();
     private String elementId;
     private String elementName;
     private String elementType;
@@ -64,6 +66,14 @@ public class BpmnDiagramCheckResult {
 
     public void setElementType(String elementType) {
       this.elementType = elementType;
+    }
+
+    public List<String> getReferences() {
+      return references;
+    }
+
+    public List<String> getReferencedBy() {
+      return referencedBy;
     }
   }
 

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/ConversionElementAppender.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/ConversionElementAppender.java
@@ -8,19 +8,38 @@ import org.camunda.bpm.model.xml.instance.DomDocument;
 import org.camunda.bpm.model.xml.instance.DomElement;
 import org.camunda.community.migration.converter.BpmnDiagramCheckResult.BpmnElementCheckMessage;
 
-public class MessageAppender {
+public class ConversionElementAppender {
 
-  public void appendMessages(
-      DomElement element, List<BpmnElementCheckMessage> messages, boolean appendDocumentation) {
+  public void appendMessages(DomElement element, List<BpmnElementCheckMessage> messages) {
     if (!messages.isEmpty()) {
       DomElement extensionElements = getExtensionElements(element);
       messages.sort(Comparator.comparingInt(message -> message.getSeverity().ordinal()));
       messages.forEach(
           message -> extensionElements.appendChild(createMessage(message, element.getDocument())));
-      if (appendDocumentation) {
-        DomElement documentation = getDocumentation(element);
-        documentation.setTextContent(createDocumentation(documentation.getTextContent(), messages));
-      }
+    }
+  }
+
+  public void appendDocumentation(DomElement element, List<BpmnElementCheckMessage> messages) {
+    DomElement documentation = getDocumentation(element);
+    documentation.setTextContent(createDocumentation(documentation.getTextContent(), messages));
+  }
+
+  public void appendReferences(DomElement element, List<String> references) {
+    if (!references.isEmpty()) {
+      DomElement extensionElements = getExtensionElements(element);
+      references.forEach(
+          reference ->
+              extensionElements.appendChild(createReference(reference, element.getDocument())));
+    }
+  }
+
+  public void appendReferencedBy(DomElement element, List<String> referencedBys) {
+    if (!referencedBys.isEmpty()) {
+      DomElement extensionElements = getExtensionElements(element);
+      referencedBys.forEach(
+          referencedBy ->
+              extensionElements.appendChild(
+                  createReferencedBy(referencedBy, element.getDocument())));
     }
   }
 
@@ -47,5 +66,17 @@ public class MessageAppender {
     }
     messageElement.setTextContent(message.getMessage());
     return messageElement;
+  }
+
+  private DomElement createReference(String reference, DomDocument document) {
+    DomElement referenceElement = document.createElement(NamespaceUri.CONVERSION, "reference");
+    referenceElement.setTextContent(reference);
+    return referenceElement;
+  }
+
+  private DomElement createReferencedBy(String referencedBy, DomDocument document) {
+    DomElement referenceElement = document.createElement(NamespaceUri.CONVERSION, "referencedBy");
+    referenceElement.setTextContent(referencedBy);
+    return referenceElement;
   }
 }

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/AbstractAttributeVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/AbstractAttributeVisitor.java
@@ -4,7 +4,6 @@ import org.camunda.community.migration.converter.DomElementVisitorContext;
 import org.camunda.community.migration.converter.NamespaceUri;
 
 public abstract class AbstractAttributeVisitor extends AbstractFilteringVisitor {
-
   @Override
   protected void visitFilteredElement(DomElementVisitorContext context) {
     String attribute = context.getElement().getAttribute(namespaceUri(), attributeLocalName());
@@ -24,17 +23,13 @@ public abstract class AbstractAttributeVisitor extends AbstractFilteringVisitor 
         && context.getElement().getNamespaceURI().equals(NamespaceUri.BPMN);
   }
 
-  protected String namespaceUri() {
-    return NamespaceUri.CAMUNDA;
-  }
+  protected abstract String namespaceUri();
 
   public abstract String attributeLocalName();
 
   protected abstract void visitAttribute(DomElementVisitorContext context, String attribute);
 
-  protected boolean removeAttribute() {
-    return true;
-  }
+  protected abstract boolean removeAttribute();
 
   @Override
   protected void logVisit(DomElementVisitorContext context) {

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/AbstractBpmnAttributeVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/AbstractBpmnAttributeVisitor.java
@@ -1,0 +1,15 @@
+package org.camunda.community.migration.converter.visitor;
+
+import org.camunda.community.migration.converter.NamespaceUri;
+
+public abstract class AbstractBpmnAttributeVisitor extends AbstractAttributeVisitor {
+  @Override
+  protected String namespaceUri() {
+    return NamespaceUri.BPMN;
+  }
+
+  @Override
+  protected boolean removeAttribute() {
+    return false;
+  }
+}

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/AbstractCamundaAttributeVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/AbstractCamundaAttributeVisitor.java
@@ -1,0 +1,25 @@
+package org.camunda.community.migration.converter.visitor;
+
+import org.camunda.community.migration.converter.DomElementVisitorContext;
+import org.camunda.community.migration.converter.NamespaceUri;
+
+public abstract class AbstractCamundaAttributeVisitor extends AbstractAttributeVisitor {
+
+  protected String namespaceUri() {
+    return NamespaceUri.CAMUNDA;
+  }
+
+  protected boolean removeAttribute() {
+    return true;
+  }
+
+  @Override
+  protected void logVisit(DomElementVisitorContext context) {
+    LOG.debug(
+        "Visiting attribute '{}:{}' on element '{}:{}'",
+        namespaceUri(),
+        attributeLocalName(),
+        context.getElement().getPrefix(),
+        context.getElement().getLocalName());
+  }
+}

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/AbstractCurrentlyNotSupportedAttributeVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/AbstractCurrentlyNotSupportedAttributeVisitor.java
@@ -4,7 +4,7 @@ import org.camunda.community.migration.converter.DomElementVisitorContext;
 import org.camunda.community.migration.converter.message.MessageFactory;
 
 public abstract class AbstractCurrentlyNotSupportedAttributeVisitor
-    extends AbstractAttributeVisitor {
+    extends AbstractCamundaAttributeVisitor {
 
   @Override
   protected final void visitAttribute(DomElementVisitorContext context, String attribute) {

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/AbstractEventRefVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/AbstractEventRefVisitor.java
@@ -1,0 +1,11 @@
+package org.camunda.community.migration.converter.visitor;
+
+import org.camunda.community.migration.converter.DomElementVisitorContext;
+
+public abstract class AbstractEventRefVisitor extends AbstractBpmnAttributeVisitor {
+
+  @Override
+  protected void visitAttribute(DomElementVisitorContext context, String attribute) {
+    context.references(attribute);
+  }
+}

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/AbstractRemoveAttributeVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/AbstractRemoveAttributeVisitor.java
@@ -3,7 +3,7 @@ package org.camunda.community.migration.converter.visitor;
 import org.camunda.community.migration.converter.DomElementVisitorContext;
 import org.camunda.community.migration.converter.message.MessageFactory;
 
-public abstract class AbstractRemoveAttributeVisitor extends AbstractAttributeVisitor {
+public abstract class AbstractRemoveAttributeVisitor extends AbstractCamundaAttributeVisitor {
 
   @Override
   protected void visitAttribute(DomElementVisitorContext context, String attribute) {

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/AbstractSupportedAttributeVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/AbstractSupportedAttributeVisitor.java
@@ -3,7 +3,7 @@ package org.camunda.community.migration.converter.visitor;
 import org.camunda.community.migration.converter.DomElementVisitorContext;
 import org.camunda.community.migration.converter.message.Message;
 
-public abstract class AbstractSupportedAttributeVisitor extends AbstractAttributeVisitor {
+public abstract class AbstractSupportedAttributeVisitor extends AbstractCamundaAttributeVisitor {
 
   @Override
   protected void visitAttribute(DomElementVisitorContext context, String attribute) {

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/ErrorRefVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/ErrorRefVisitor.java
@@ -1,0 +1,10 @@
+package org.camunda.community.migration.converter.visitor.impl;
+
+import org.camunda.community.migration.converter.visitor.AbstractEventRefVisitor;
+
+public class ErrorRefVisitor extends AbstractEventRefVisitor {
+  @Override
+  public String attributeLocalName() {
+    return "errorRef";
+  }
+}

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/EscalationRefVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/EscalationRefVisitor.java
@@ -1,0 +1,10 @@
+package org.camunda.community.migration.converter.visitor.impl;
+
+import org.camunda.community.migration.converter.visitor.AbstractEventRefVisitor;
+
+public class EscalationRefVisitor extends AbstractEventRefVisitor {
+  @Override
+  public String attributeLocalName() {
+    return "escalationRef";
+  }
+}

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/MessageRefVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/MessageRefVisitor.java
@@ -1,0 +1,10 @@
+package org.camunda.community.migration.converter.visitor.impl;
+
+import org.camunda.community.migration.converter.visitor.AbstractEventRefVisitor;
+
+public class MessageRefVisitor extends AbstractEventRefVisitor {
+  @Override
+  public String attributeLocalName() {
+    return "messageRef";
+  }
+}

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/SignalRefVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/SignalRefVisitor.java
@@ -1,0 +1,10 @@
+package org.camunda.community.migration.converter.visitor.impl;
+
+import org.camunda.community.migration.converter.visitor.AbstractEventRefVisitor;
+
+public class SignalRefVisitor extends AbstractEventRefVisitor {
+  @Override
+  public String attributeLocalName() {
+    return "signalRef";
+  }
+}

--- a/backend-diagram-converter/core/src/main/resources/META-INF/services/org.camunda.community.migration.converter.visitor.DomElementVisitor
+++ b/backend-diagram-converter/core/src/main/resources/META-INF/services/org.camunda.community.migration.converter.visitor.DomElementVisitor
@@ -131,3 +131,7 @@ org.camunda.community.migration.converter.visitor.impl.element.FailedJobRetryTim
 org.camunda.community.migration.converter.visitor.impl.LaneVisitor
 org.camunda.community.migration.converter.visitor.impl.LaneSetVisitor
 org.camunda.community.migration.converter.visitor.impl.FlowNodeRefVisitor
+org.camunda.community.migration.converter.visitor.impl.EscalationRefVisitor
+org.camunda.community.migration.converter.visitor.impl.ErrorRefVisitor
+org.camunda.community.migration.converter.visitor.impl.SignalRefVisitor
+org.camunda.community.migration.converter.visitor.impl.MessageRefVisitor

--- a/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/BpmnConverterTest.java
+++ b/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/BpmnConverterTest.java
@@ -176,15 +176,15 @@ public class BpmnConverterTest {
 
   @Test
   void testReferences() {
-    BpmnDiagramCheckResult result = loadAndCheck("message-example.-.Kopie.bpmn");
-    BpmnElementCheckResult receiveTask = result.getResult("Activity_1yvxtxm");
+    BpmnDiagramCheckResult result = loadAndCheck("message-example.bpmn");
+    BpmnElementCheckResult receiveTask = result.getResult("Receive1Task");
     assertThat(receiveTask).isNotNull();
     assertThat(receiveTask.getReferences()).hasSize(1);
-    assertThat(receiveTask.getReferences().get(0)).isEqualTo("Message_13r2bfr");
-    BpmnElementCheckResult message = result.getResult("Message_13r2bfr");
+    assertThat(receiveTask.getReferences().get(0)).isEqualTo("Receive1Message");
+    BpmnElementCheckResult message = result.getResult("Receive1Message");
     assertThat(message).isNotNull();
     assertThat(message.getReferencedBy()).hasSize(1);
-    assertThat(message.getReferencedBy().get(0)).isEqualTo("Activity_1yvxtxm");
+    assertThat(message.getReferencedBy().get(0)).isEqualTo("Receive1Task");
   }
 
   protected BpmnDiagramCheckResult loadAndCheck(String bpmnFile) {

--- a/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/BpmnConverterTest.java
+++ b/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/BpmnConverterTest.java
@@ -174,6 +174,19 @@ public class BpmnConverterTest {
     assertThat(callActivityResult.getMessages().get(3).getSeverity()).isEqualTo(Severity.INFO);
   }
 
+  @Test
+  void testReferences() {
+    BpmnDiagramCheckResult result = loadAndCheck("message-example.-.Kopie.bpmn");
+    BpmnElementCheckResult receiveTask = result.getResult("Activity_1yvxtxm");
+    assertThat(receiveTask).isNotNull();
+    assertThat(receiveTask.getReferences()).hasSize(1);
+    assertThat(receiveTask.getReferences().get(0)).isEqualTo("Message_13r2bfr");
+    BpmnElementCheckResult message = result.getResult("Message_13r2bfr");
+    assertThat(message).isNotNull();
+    assertThat(message.getReferencedBy()).hasSize(1);
+    assertThat(message.getReferencedBy().get(0)).isEqualTo("Activity_1yvxtxm");
+  }
+
   protected BpmnDiagramCheckResult loadAndCheck(String bpmnFile) {
     ConverterProperties properties = ConverterPropertiesFactory.getInstance().get();
     return loadAndCheckAgainstVersion(bpmnFile, properties.getPlatformVersion());

--- a/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/CoverageTest.java
+++ b/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/CoverageTest.java
@@ -39,6 +39,9 @@ public class CoverageTest {
           .collect(Collectors.toSet());
   private static final Set<String> EVENT_REFERENCE_TYPES =
       Stream.of("error", "escalation", "message", "signal").collect(Collectors.toSet());
+
+  private static final Set<String> EVENT_REF_TYPES =
+      Stream.of("messageRef", "escalationRef", "errorRef", "signalRef").collect(Collectors.toSet());
   private static final Set<String> EVENT_TYPES =
       Stream.of(
               "startEvent",
@@ -126,6 +129,11 @@ public class CoverageTest {
   void shouldCoverLanes() {
     assertThat(getCoveredElements())
         .containsAll(Stream.of("lane", "laneSet", "flowNodeRef").collect(Collectors.toSet()));
+  }
+
+  @Test
+  void shouldCoverEventRefs() {
+    assertThat(getCoveredAttributes()).containsAll(EVENT_REF_TYPES);
   }
 
   private Set<String> getCoveredEventDefinitionTypes() {

--- a/backend-diagram-converter/core/src/test/resources/message-example.-.Kopie.bpmn
+++ b/backend-diagram-converter/core/src/test/resources/message-example.-.Kopie.bpmn
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1v49kyn" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.5.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.18.0">
+  <bpmn:process id="MessageExampleProcess" name="Message example process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Example wanted">
+      <bpmn:outgoing>Flow_0qha59z</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0u16von" />
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0qha59z" sourceRef="StartEvent_1" targetRef="Activity_1dr9i1z" />
+    <bpmn:sendTask id="Activity_1dr9i1z" name="Send 1" camunda:type="external" camunda:topic="sending">
+      <bpmn:incoming>Flow_0qha59z</bpmn:incoming>
+      <bpmn:incoming>Flow_137agdz</bpmn:incoming>
+      <bpmn:outgoing>Flow_1jh0h9o</bpmn:outgoing>
+    </bpmn:sendTask>
+    <bpmn:sequenceFlow id="Flow_1jh0h9o" sourceRef="Activity_1dr9i1z" targetRef="Activity_1yvxtxm" />
+    <bpmn:receiveTask id="Activity_1yvxtxm" name="Receive 1" messageRef="Message_13r2bfr">
+      <bpmn:incoming>Flow_1jh0h9o</bpmn:incoming>
+      <bpmn:outgoing>Flow_1iz74y6</bpmn:outgoing>
+    </bpmn:receiveTask>
+    <bpmn:sequenceFlow id="Flow_1iz74y6" sourceRef="Activity_1yvxtxm" targetRef="Activity_1qp15tw" />
+    <bpmn:subProcess id="Activity_1qp15tw">
+      <bpmn:incoming>Flow_1iz74y6</bpmn:incoming>
+      <bpmn:outgoing>Flow_1ld1wh7</bpmn:outgoing>
+      <bpmn:startEvent id="Event_0ttk9zf">
+        <bpmn:outgoing>Flow_10jxl23</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_10jxl23" sourceRef="Event_0ttk9zf" targetRef="Event_11ut8bx" />
+      <bpmn:intermediateThrowEvent id="Event_11ut8bx" name="Sent 2">
+        <bpmn:incoming>Flow_10jxl23</bpmn:incoming>
+        <bpmn:outgoing>Flow_00v47o2</bpmn:outgoing>
+        <bpmn:messageEventDefinition id="MessageEventDefinition_0z6wwhr" messageRef="Message_0c0p7ku" camunda:type="external" camunda:topic="sending" />
+      </bpmn:intermediateThrowEvent>
+      <bpmn:sequenceFlow id="Flow_00v47o2" sourceRef="Event_11ut8bx" targetRef="Event_03g9s2b" />
+      <bpmn:intermediateCatchEvent id="Event_03g9s2b" name="Received 2">
+        <bpmn:incoming>Flow_00v47o2</bpmn:incoming>
+        <bpmn:outgoing>Flow_0dw4bin</bpmn:outgoing>
+        <bpmn:messageEventDefinition id="MessageEventDefinition_0k85pgm" messageRef="Message_20o085u" />
+      </bpmn:intermediateCatchEvent>
+      <bpmn:endEvent id="Event_10zfpvr">
+        <bpmn:incoming>Flow_0dw4bin</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_0dw4bin" sourceRef="Event_03g9s2b" targetRef="Event_10zfpvr" />
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_1ld1wh7" sourceRef="Activity_1qp15tw" targetRef="Event_0yabkd4" />
+    <bpmn:endEvent id="Event_0yabkd4" name="Done">
+      <bpmn:incoming>Flow_1ld1wh7</bpmn:incoming>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1luqdsx" messageRef="Message_3nsuobg" camunda:type="external" camunda:topic="sending" />
+    </bpmn:endEvent>
+    <bpmn:boundaryEvent id="Event_05w5fuw" name="Try again" cancelActivity="false" attachedToRef="Activity_1qp15tw">
+      <bpmn:outgoing>Flow_137agdz</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0xqycwf" messageRef="Message_0n09ges" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_137agdz" sourceRef="Event_05w5fuw" targetRef="Activity_1dr9i1z" />
+    <bpmn:boundaryEvent id="Event_1tpgyge" name="Failed" attachedToRef="Activity_1qp15tw">
+      <bpmn:outgoing>Flow_0w8dgqb</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1exs0mn" messageRef="Message_3gv4u4b" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_0w8dgqb" sourceRef="Event_1tpgyge" targetRef="Event_15jkb4h" />
+    <bpmn:endEvent id="Event_15jkb4h" name="Failed with error">
+      <bpmn:incoming>Flow_0w8dgqb</bpmn:incoming>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_0odhxe3" />
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmn:message id="Message_13r2bfr" name="receiveMessage1" />
+  <bpmn:message id="Message_0c0p7ku" name="sentMessage2" />
+  <bpmn:message id="Message_20o085u" name="receiveMessage2" />
+  <bpmn:message id="Message_0n09ges" name="tryAgainMessage" />
+  <bpmn:message id="Message_3gv4u4b" name="failedMessage" />
+  <bpmn:message id="Message_3nsuobg" name="doneMessage" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MessageExampleProcess">
+      <bpmndi:BPMNShape id="Event_0yljmvy_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="159" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="156" y="202" width="82" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ugoc1h_di" bpmnElement="Activity_1dr9i1z">
+        <dc:Bounds x="270" y="137" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ay3ku8_di" bpmnElement="Activity_1yvxtxm">
+        <dc:Bounds x="430" y="137" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ggj47u_di" bpmnElement="Event_0yabkd4">
+        <dc:Bounds x="1072" y="159" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1077" y="202" width="27" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1i6zqrb_di" bpmnElement="Event_15jkb4h">
+        <dc:Bounds x="882" y="342" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="860" y="385" width="81" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1muepl7_di" bpmnElement="Activity_1qp15tw" isExpanded="true">
+        <dc:Bounds x="590" y="77" width="420" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ttk9zf_di" bpmnElement="Event_0ttk9zf">
+        <dc:Bounds x="630.3333333333334" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_077egt5_di" bpmnElement="Event_11ut8bx">
+        <dc:Bounds x="722" y="159" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="724" y="202" width="32" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_16mo3jf_di" bpmnElement="Event_03g9s2b">
+        <dc:Bounds x="822" y="159" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="812" y="202" width="56" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_10zfpvr_di" bpmnElement="Event_10zfpvr">
+        <dc:Bounds x="922" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_10jxl23_di" bpmnElement="Flow_10jxl23">
+        <di:waypoint x="666" y="177" />
+        <di:waypoint x="722" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_00v47o2_di" bpmnElement="Flow_00v47o2">
+        <di:waypoint x="758" y="177" />
+        <di:waypoint x="822" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0dw4bin_di" bpmnElement="Flow_0dw4bin">
+        <di:waypoint x="858" y="177" />
+        <di:waypoint x="922" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_1tv8uxc_di" bpmnElement="Event_05w5fuw">
+        <dc:Bounds x="672" y="259" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="668" y="302" width="45" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0he5rvh_di" bpmnElement="Event_1tpgyge">
+        <dc:Bounds x="792" y="259" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="795" y="302" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0qha59z_di" bpmnElement="Flow_0qha59z">
+        <di:waypoint x="215" y="177" />
+        <di:waypoint x="270" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1jh0h9o_di" bpmnElement="Flow_1jh0h9o">
+        <di:waypoint x="370" y="177" />
+        <di:waypoint x="430" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1iz74y6_di" bpmnElement="Flow_1iz74y6">
+        <di:waypoint x="530" y="177" />
+        <di:waypoint x="590" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ld1wh7_di" bpmnElement="Flow_1ld1wh7">
+        <di:waypoint x="1010" y="177" />
+        <di:waypoint x="1072" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_137agdz_di" bpmnElement="Flow_137agdz">
+        <di:waypoint x="690" y="295" />
+        <di:waypoint x="690" y="360" />
+        <di:waypoint x="320" y="360" />
+        <di:waypoint x="320" y="217" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0w8dgqb_di" bpmnElement="Flow_0w8dgqb">
+        <di:waypoint x="810" y="295" />
+        <di:waypoint x="810" y="360" />
+        <di:waypoint x="882" y="360" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/backend-diagram-converter/core/src/test/resources/message-example.bpmn
+++ b/backend-diagram-converter/core/src/test/resources/message-example.bpmn
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1v49kyn" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.5.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.18.0">
-  <bpmn:process id="MessageExampleProcess" name="Message example process" isExecutable="true">
-    <bpmn:startEvent id="StartEvent_1" name="Example wanted">
+  <bpmn:process id="MessageExampleProcessProcess" name="Message example process" isExecutable="true">
+    <bpmn:startEvent id="ExampleWantedStartEvent" name="Example wanted">
       <bpmn:outgoing>Flow_0qha59z</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_0u16von" />
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="Flow_0qha59z" sourceRef="StartEvent_1" targetRef="Activity_1dr9i1z" />
-    <bpmn:sendTask id="Activity_1dr9i1z" name="Send 1" camunda:type="external" camunda:topic="sending">
+    <bpmn:sequenceFlow id="Flow_0qha59z" sourceRef="ExampleWantedStartEvent" targetRef="Send1Task" />
+    <bpmn:sendTask id="Send1Task" name="Send 1" camunda:type="external" camunda:topic="sending">
       <bpmn:incoming>Flow_0qha59z</bpmn:incoming>
       <bpmn:incoming>Flow_137agdz</bpmn:incoming>
       <bpmn:outgoing>Flow_1jh0h9o</bpmn:outgoing>
     </bpmn:sendTask>
-    <bpmn:sequenceFlow id="Flow_1jh0h9o" sourceRef="Activity_1dr9i1z" targetRef="Activity_1yvxtxm" />
-    <bpmn:receiveTask id="Activity_1yvxtxm" name="Receive 1" messageRef="Message_13r2bfr">
+    <bpmn:sequenceFlow id="Flow_1jh0h9o" sourceRef="Send1Task" targetRef="Receive1Task" />
+    <bpmn:receiveTask id="Receive1Task" name="Receive 1" messageRef="Receive1Message">
       <bpmn:incoming>Flow_1jh0h9o</bpmn:incoming>
       <bpmn:outgoing>Flow_1iz74y6</bpmn:outgoing>
     </bpmn:receiveTask>
-    <bpmn:sequenceFlow id="Flow_1iz74y6" sourceRef="Activity_1yvxtxm" targetRef="Activity_1qp15tw" />
+    <bpmn:sequenceFlow id="Flow_1iz74y6" sourceRef="Receive1Task" targetRef="Activity_1qp15tw" />
     <bpmn:subProcess id="Activity_1qp15tw">
       <bpmn:incoming>Flow_1iz74y6</bpmn:incoming>
       <bpmn:outgoing>Flow_1ld1wh7</bpmn:outgoing>
       <bpmn:startEvent id="Event_0ttk9zf">
         <bpmn:outgoing>Flow_10jxl23</bpmn:outgoing>
       </bpmn:startEvent>
-      <bpmn:sequenceFlow id="Flow_10jxl23" sourceRef="Event_0ttk9zf" targetRef="Event_11ut8bx" />
-      <bpmn:intermediateThrowEvent id="Event_11ut8bx" name="Sent 2">
+      <bpmn:sequenceFlow id="Flow_10jxl23" sourceRef="Event_0ttk9zf" targetRef="Sent2Event" />
+      <bpmn:intermediateThrowEvent id="Sent2Event" name="Sent 2">
         <bpmn:incoming>Flow_10jxl23</bpmn:incoming>
         <bpmn:outgoing>Flow_00v47o2</bpmn:outgoing>
         <bpmn:messageEventDefinition id="MessageEventDefinition_0z6wwhr" messageRef="Message_0c0p7ku" camunda:type="external" camunda:topic="sending" />
       </bpmn:intermediateThrowEvent>
-      <bpmn:sequenceFlow id="Flow_00v47o2" sourceRef="Event_11ut8bx" targetRef="Event_03g9s2b" />
-      <bpmn:intermediateCatchEvent id="Event_03g9s2b" name="Received 2">
+      <bpmn:sequenceFlow id="Flow_00v47o2" sourceRef="Sent2Event" targetRef="Received2Event" />
+      <bpmn:intermediateCatchEvent id="Received2Event" name="Received 2">
         <bpmn:incoming>Flow_00v47o2</bpmn:incoming>
         <bpmn:outgoing>Flow_0dw4bin</bpmn:outgoing>
         <bpmn:messageEventDefinition id="MessageEventDefinition_0k85pgm" messageRef="Message_20o085u" />
@@ -38,61 +38,49 @@
       <bpmn:endEvent id="Event_10zfpvr">
         <bpmn:incoming>Flow_0dw4bin</bpmn:incoming>
       </bpmn:endEvent>
-      <bpmn:sequenceFlow id="Flow_0dw4bin" sourceRef="Event_03g9s2b" targetRef="Event_10zfpvr" />
+      <bpmn:sequenceFlow id="Flow_0dw4bin" sourceRef="Received2Event" targetRef="Event_10zfpvr" />
     </bpmn:subProcess>
-    <bpmn:sequenceFlow id="Flow_1ld1wh7" sourceRef="Activity_1qp15tw" targetRef="Event_0yabkd4" />
-    <bpmn:endEvent id="Event_0yabkd4" name="Done">
+    <bpmn:sequenceFlow id="Flow_1ld1wh7" sourceRef="Activity_1qp15tw" targetRef="DoneEndEvent" />
+    <bpmn:endEvent id="DoneEndEvent" name="Done">
       <bpmn:incoming>Flow_1ld1wh7</bpmn:incoming>
       <bpmn:messageEventDefinition id="MessageEventDefinition_1luqdsx" messageRef="Message_3nsuobg" camunda:type="external" camunda:topic="sending" />
     </bpmn:endEvent>
-    <bpmn:boundaryEvent id="Event_05w5fuw" name="Try again" cancelActivity="false" attachedToRef="Activity_1qp15tw">
+    <bpmn:boundaryEvent id="TryAgainBoundaryEvent" name="Try again" cancelActivity="false" attachedToRef="Activity_1qp15tw">
       <bpmn:outgoing>Flow_137agdz</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_0xqycwf" messageRef="Message_0n09ges" />
     </bpmn:boundaryEvent>
-    <bpmn:sequenceFlow id="Flow_137agdz" sourceRef="Event_05w5fuw" targetRef="Activity_1dr9i1z" />
-    <bpmn:boundaryEvent id="Event_1tpgyge" name="Failed" attachedToRef="Activity_1qp15tw">
+    <bpmn:sequenceFlow id="Flow_137agdz" sourceRef="TryAgainBoundaryEvent" targetRef="Send1Task" />
+    <bpmn:boundaryEvent id="FailedBoundaryEvent" name="Failed" attachedToRef="Activity_1qp15tw">
       <bpmn:outgoing>Flow_0w8dgqb</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_1exs0mn" messageRef="Message_3gv4u4b" />
     </bpmn:boundaryEvent>
-    <bpmn:sequenceFlow id="Flow_0w8dgqb" sourceRef="Event_1tpgyge" targetRef="Event_15jkb4h" />
-    <bpmn:endEvent id="Event_15jkb4h" name="Failed with error">
+    <bpmn:sequenceFlow id="Flow_0w8dgqb" sourceRef="FailedBoundaryEvent" targetRef="FailedWithErrorEndEvent" />
+    <bpmn:endEvent id="FailedWithErrorEndEvent" name="Failed with error">
       <bpmn:incoming>Flow_0w8dgqb</bpmn:incoming>
       <bpmn:errorEventDefinition id="ErrorEventDefinition_0odhxe3" />
     </bpmn:endEvent>
   </bpmn:process>
-  <bpmn:message id="Message_13r2bfr" name="receiveMessage1" />
+  <bpmn:message id="Receive1Message" name="receiveMessage1" />
   <bpmn:message id="Message_0c0p7ku" name="sentMessage2" />
   <bpmn:message id="Message_20o085u" name="receiveMessage2" />
   <bpmn:message id="Message_0n09ges" name="tryAgainMessage" />
   <bpmn:message id="Message_3gv4u4b" name="failedMessage" />
   <bpmn:message id="Message_3nsuobg" name="doneMessage" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MessageExampleProcess">
-      <bpmndi:BPMNShape id="Event_0yljmvy_di" bpmnElement="StartEvent_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MessageExampleProcessProcess">
+      <bpmndi:BPMNShape id="Event_0yljmvy_di" bpmnElement="ExampleWantedStartEvent">
         <dc:Bounds x="179" y="159" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="156" y="202" width="82" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0ugoc1h_di" bpmnElement="Activity_1dr9i1z">
+      <bpmndi:BPMNShape id="Activity_0ugoc1h_di" bpmnElement="Send1Task">
         <dc:Bounds x="270" y="137" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0ay3ku8_di" bpmnElement="Activity_1yvxtxm">
+      <bpmndi:BPMNShape id="Activity_0ay3ku8_di" bpmnElement="Receive1Task">
         <dc:Bounds x="430" y="137" width="100" height="80" />
         <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1ggj47u_di" bpmnElement="Event_0yabkd4">
-        <dc:Bounds x="1072" y="159" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1077" y="202" width="27" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1i6zqrb_di" bpmnElement="Event_15jkb4h">
-        <dc:Bounds x="882" y="342" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="860" y="385" width="81" height="14" />
-        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1muepl7_di" bpmnElement="Activity_1qp15tw" isExpanded="true">
         <dc:Bounds x="590" y="77" width="420" height="200" />
@@ -100,13 +88,13 @@
       <bpmndi:BPMNShape id="Event_0ttk9zf_di" bpmnElement="Event_0ttk9zf">
         <dc:Bounds x="630.3333333333334" y="159" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_077egt5_di" bpmnElement="Event_11ut8bx">
+      <bpmndi:BPMNShape id="Event_077egt5_di" bpmnElement="Sent2Event">
         <dc:Bounds x="722" y="159" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="724" y="202" width="32" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_16mo3jf_di" bpmnElement="Event_03g9s2b">
+      <bpmndi:BPMNShape id="Event_16mo3jf_di" bpmnElement="Received2Event">
         <dc:Bounds x="822" y="159" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="812" y="202" width="56" height="14" />
@@ -127,16 +115,28 @@
         <di:waypoint x="858" y="177" />
         <di:waypoint x="922" y="177" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Event_1tv8uxc_di" bpmnElement="Event_05w5fuw">
-        <dc:Bounds x="672" y="259" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_1ggj47u_di" bpmnElement="DoneEndEvent">
+        <dc:Bounds x="1072" y="159" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="668" y="302" width="45" height="14" />
+          <dc:Bounds x="1077" y="202" width="27" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0he5rvh_di" bpmnElement="Event_1tpgyge">
+      <bpmndi:BPMNShape id="Event_1i6zqrb_di" bpmnElement="FailedWithErrorEndEvent">
+        <dc:Bounds x="882" y="342" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="861" y="385" width="80" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0he5rvh_di" bpmnElement="FailedBoundaryEvent">
         <dc:Bounds x="792" y="259" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="795" y="302" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1tv8uxc_di" bpmnElement="TryAgainBoundaryEvent">
+        <dc:Bounds x="672" y="259" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="668" y="302" width="46" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_0qha59z_di" bpmnElement="Flow_0qha59z">

--- a/backend-diagram-converter/webapp/src/main/resources/static/lib/property-info-plugin.js
+++ b/backend-diagram-converter/webapp/src/main/resources/static/lib/property-info-plugin.js
@@ -2,38 +2,37 @@
  * Load modeler instance with Camunda-Moddle extension and show all properties
  */
 async function getCamundaModdle() {
-    try {
-        const response = await fetch('https://unpkg.com/camunda-bpmn-moddle@7.0.1/resources/camunda.json')
-        if (!response.ok) {
-            throw new Error(`HTTP Error: ${response.status}`)
-        }
-        const data = await response.json();
-        return data;
+  try {
+    const response = await fetch('https://unpkg.com/camunda-bpmn-moddle@7.0.1/resources/camunda.json')
+    if (!response.ok) {
+      throw new Error(`HTTP Error: ${response.status}`)
     }
-    catch (error) {
-       console.error(`could not get Camunda moddle: ${error}`);
-    }
-} 
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error(`could not get Camunda moddle: ${error}`);
+  }
+}
 
 let bpmnViewer = null;
 
 async function getBpmnViewer() {
-  
+
   if (!bpmnViewer) {
-    
+
     const camundaModdle = await getCamundaModdle();
-    
+
     console.log(camundaModdle);
-    
+
     // viewer instance
     bpmnViewer = new BpmnJS({
       container: '#canvas',
-       moddleExtensions: {
-           camunda: camundaModdle
-       }
+      moddleExtensions: {
+        camunda: camundaModdle
+      }
     });
   }
-  
+
   return bpmnViewer;
 }
 
@@ -53,264 +52,263 @@ async function openDiagram(bpmnXML, bpmnViewer) {
     var canvas = bpmnViewer.get('canvas');
     // zoom to fit full viewport
     canvas.zoom('fit-viewport');
-    
-    } catch (err) {
-        
-        console.error('could not import BPMN 2.0 diagram', err);
-    }
+
+  } catch (err) {
+
+    console.error('could not import BPMN 2.0 diagram', err);
+  }
 }
 
 async function showPropertyInfos() {
   bpmnViewer = await getBpmnViewer()
   var overlays = bpmnViewer.get('overlays');
   var elementRegistry = bpmnViewer.get('elementRegistry');
-  
+
   var elements = elementRegistry.getAll();
   for (var elementCount in elements) {
-      var elementObject = elements[elementCount];
-      if (elementObject.businessObject.$instanceOf('bpmn:FlowNode') || elementObject.businessObject.$instanceOf('bpmn:Participant')) {
-          addStyle(elementObject, overlays);
-      }
+    var elementObject = elements[elementCount];
+    if (elementObject.businessObject.$instanceOf('bpmn:FlowNode') || elementObject.businessObject.$instanceOf('bpmn:Participant')) {
+      addStyle(elementObject, overlays);
+    }
   }
 }
 
 function addStyle(element, overlays) {
-    
-    var elementOverlays = [];
-    
-        
-    // if (elementOverlays[element.id] !== undefined && elementOverlays[element.id].length !== 0) {
-    //     for (var overlay in elementOverlays[element.id]) {
-    //         overlays.remove(elementOverlays[element.id][overlay]);
-    //     }
-    // }
 
-    elementOverlays[element.id] = [];
-
-    if( element.businessObject.documentation !== undefined &&
-        element.businessObject.documentation.length > 0 &&
-        element.businessObject.documentation[0].text.trim() !== "" &&
-        element.type !== "label"){
-
-        var text = element.businessObject.documentation[0].text;
-        text = text.replace(/(?:\r\n|\r|\n)/g, '<br />');
+  var elementOverlays = [];
 
 
-        elementOverlays[element.id].push(
+  // if (elementOverlays[element.id] !== undefined && elementOverlays[element.id].length !== 0) {
+  //     for (var overlay in elementOverlays[element.id]) {
+  //         overlays.remove(elementOverlays[element.id][overlay]);
+  //     }
+  // }
+
+  elementOverlays[element.id] = [];
+
+  if (element.businessObject.documentation !== undefined &&
+      element.businessObject.documentation.length > 0 &&
+      element.businessObject.documentation[0].text.trim() !== "" &&
+      element.type !== "label") {
+
+    var text = element.businessObject.documentation[0].text;
+    text = text.replace(/(?:\r\n|\r|\n)/g, '<br />');
+
+
+    elementOverlays[element.id].push(
         overlays.add(element, 'badge', {
-            position: {
-                top: 4,
-                right: 4
-            },
-            html: '<div class="doc-val-true" data-badge="D"></div><div class="doc-val-hover" data-badge="D">'+text+'</div>'
+          position: {
+            top: 4,
+            right: 4
+          },
+          html: '<div class="doc-val-true" data-badge="D"></div><div class="doc-val-hover" data-badge="D">' + text + '</div>'
         }));
+  }
+
+  if (element.businessObject.extensionElements === undefined && element.businessObject.$instanceOf('bpmn:FlowNode')) {
+    return;
+  }
+
+  //Do not process the label of an element
+  if (element.type === "label") {
+    return;
+  }
+
+  var badges = [];
+
+  if (element.businessObject.$instanceOf('bpmn:Participant')) {
+    var extensionElements = element.businessObject.processRef.extensionElements;
+    var extensions = (extensionElements === undefined ? [] : extensionElements.values);
+
+    var type = '&#9654;';
+    var background = 'prop-info-green';
+    if (element.businessObject.processRef.isExecutable === false) {
+      type = '&#10074;&#10074;';
+      background = 'prop-info-red';
     }
+    badges.push({
+      badgeKey: 'isExecutable',
+      badgeSort: 0,
+      badgeType: type,
+      badgeBackground: background,
+      badgeLocation: 'left'
+    });
+  } else {
+    var extensions = element.businessObject.extensionElements.values;
+  }
 
-    if (element.businessObject.extensionElements === undefined && element.businessObject.$instanceOf('bpmn:FlowNode')) {
-        return;
-    }
+  for (var extension in extensions) {
+    var type = '';
+    var background = '';
+    var location = 'right';
+    var sort = 0;
+    var key = '';
 
-    //Do not process the label of an element
-    if (element.type === "label") {
-        return;
-    }
+    console.log('Extension: ', extensions[extension])
 
-    var badges = [];
-
-    if(element.businessObject.$instanceOf('bpmn:Participant')) {
-        var extensionElements = element.businessObject.processRef.extensionElements;
-        var extensions = (extensionElements === undefined ? [] : extensionElements.values);
-
-        var type = '&#9654;';
-        var background = 'prop-info-green';
-        if(element.businessObject.processRef.isExecutable === false) {
-            type = '&#10074;&#10074;';
-            background = 'prop-info-red';
-        }
-        badges.push({
-            badgeKey: 'isExecutable',
-            badgeSort: 0,
-            badgeType: type,
-            badgeBackground: background,
-            badgeLocation: 'left'
-        });
-    }
-    else {
-        var extensions = element.businessObject.extensionElements.values;
-    }
-
-    for (var extension in extensions) {
-        var type = '';
-        var background = '';
-        var location = 'right';
-        var sort = 0;
-        var key = '';
-
-        console.log('Extension: ', extensions[extension])
-        
-        switch (extensions[extension].$type) {
-            case 'camunda:ExecutionListener':
-                if (extensions[extension].event === 'start') {
-                    location = 'left';
-                    key = 'camunda:ExecutionListener-start';
-                    sort = 20;
-                } else {
-                    location = 'right';
-                    key = 'camunda:ExecutionListener-end';
-                    sort = 70;
-                }
-                type = 'L';
-                background = 'prop-info-green';
-                break;
-            case 'camunda:Properties':
-                key = 'camunda:Properties';
-                sort = 80;
-                type = 'E';
-                background = 'prop-info-violet';
-                break;
-            case 'camunda:TaskListener':
-                if (extensions[extension].event === 'create' || extensions[extension].event === 'assignment') {
-                    location = 'left';
-                    key = 'camunda:TaskListener-start';
-                    sort = 21;
-                } else {
-                    location = 'right';
-                    key = 'camunda:TaskListener-end';
-                    sort = 71;
-                }
-                type = 'T';
-                background = 'prop-info-green';
-                break;
-            case 'camunda:InputOutput':
-                background = 'prop-info-blue';
-                break;
-            case 'camunda:In':
-                type = 'V';
-                key = 'camunda:In';
-                location = 'left';
-                sort = 10;
-                background = 'prop-info-blue';
-                break;
-            case 'camunda:Out':
-                type = 'V';
-                key = 'camunda:Out';
-                location = 'right';
-                sort = 60;
-                background = 'prop-info-blue';
-                break;
-            case 'camunda:field':
-                key = 'camunda:Field';
-                sort = 90;
-                type = 'F';
-                background = 'prop-info-red';
-                break;
-        }
-
-        if (extensions[extension].$type === 'camunda:InputOutput') {
-            
-            if (extensions[extension].hasOwnProperty('inputParameters') &&
-                extensions[extension].inputParameters.length > 0) {
-                location = 'left';
-                type = 'I';
-                key = 'camunda:InputOutput-input';
-                sort = 10;
-
-                badges.push({
-                    badgeKey: key,
-                    badgeSort: sort,
-                    badgeType: type,
-                    badgeBackground: background,
-                    badgeLocation: location
-                });
-            }
-
-            if (extensions[extension].hasOwnProperty('outputParameters') &&
-                extensions[extension].outputParameters.length > 0) {
-                location = 'right';
-                type = 'O';
-                key = 'camunda:InputOutput-output';
-                sort = 60;
-
-                badges.push({
-                    badgeKey: key,
-                    badgeSort: sort,
-                    badgeType: type,
-                    badgeBackground: background,
-                    badgeLocation: location
-                });
-            }
+    switch (extensions[extension].$type) {
+      case 'camunda:ExecutionListener':
+        if (extensions[extension].event === 'start') {
+          location = 'left';
+          key = 'camunda:ExecutionListener-start';
+          sort = 20;
         } else {
-            if (key !== '') {
-                badges.push({
-                    badgeKey: key,
-                    badgeSort: sort,
-                    badgeType: type,
-                    badgeBackground: background,
-                    badgeLocation: location
-                });
-            }
+          location = 'right';
+          key = 'camunda:ExecutionListener-end';
+          sort = 70;
         }
+        type = 'L';
+        background = 'prop-info-green';
+        break;
+      case 'camunda:Properties':
+        key = 'camunda:Properties';
+        sort = 80;
+        type = 'E';
+        background = 'prop-info-violet';
+        break;
+      case 'camunda:TaskListener':
+        if (extensions[extension].event === 'create' || extensions[extension].event === 'assignment') {
+          location = 'left';
+          key = 'camunda:TaskListener-start';
+          sort = 21;
+        } else {
+          location = 'right';
+          key = 'camunda:TaskListener-end';
+          sort = 71;
+        }
+        type = 'T';
+        background = 'prop-info-green';
+        break;
+      case 'camunda:InputOutput':
+        background = 'prop-info-blue';
+        break;
+      case 'camunda:In':
+        type = 'V';
+        key = 'camunda:In';
+        location = 'left';
+        sort = 10;
+        background = 'prop-info-blue';
+        break;
+      case 'camunda:Out':
+        type = 'V';
+        key = 'camunda:Out';
+        location = 'right';
+        sort = 60;
+        background = 'prop-info-blue';
+        break;
+      case 'camunda:field':
+        key = 'camunda:Field';
+        sort = 90;
+        type = 'F';
+        background = 'prop-info-red';
+        break;
     }
 
-    addOverlays(badges, element, overlays, elementOverlays);
+    if (extensions[extension].$type === 'camunda:InputOutput') {
+
+      if (extensions[extension].hasOwnProperty('inputParameters') &&
+          extensions[extension].inputParameters.length > 0) {
+        location = 'left';
+        type = 'I';
+        key = 'camunda:InputOutput-input';
+        sort = 10;
+
+        badges.push({
+          badgeKey: key,
+          badgeSort: sort,
+          badgeType: type,
+          badgeBackground: background,
+          badgeLocation: location
+        });
+      }
+
+      if (extensions[extension].hasOwnProperty('outputParameters') &&
+          extensions[extension].outputParameters.length > 0) {
+        location = 'right';
+        type = 'O';
+        key = 'camunda:InputOutput-output';
+        sort = 60;
+
+        badges.push({
+          badgeKey: key,
+          badgeSort: sort,
+          badgeType: type,
+          badgeBackground: background,
+          badgeLocation: location
+        });
+      }
+    } else {
+      if (key !== '') {
+        badges.push({
+          badgeKey: key,
+          badgeSort: sort,
+          badgeType: type,
+          badgeBackground: background,
+          badgeLocation: location
+        });
+      }
+    }
+  }
+
+  addOverlays(badges, element, overlays, elementOverlays);
 }
 
 function addOverlays(badgeList, element, overlays, elementOverlays) {
-    var badges = [];
+  var badges = [];
 
-    var leftCounter = 0;
-    var rightCounter = 0;
+  var leftCounter = 0;
+  var rightCounter = 0;
 
 
-    var sortedBadgeList = uniqBy(badgeList, function (item) {
-        return item.badgeKey
-    });
+  var sortedBadgeList = uniqBy(badgeList, function (item) {
+    return item.badgeKey
+  });
 
-    sortedBadgeList.sort(function (a, b) {
-        return a.badgeSort - b.badgeSort;
-    });
+  sortedBadgeList.sort(function (a, b) {
+    return a.badgeSort - b.badgeSort;
+  });
 
-    for (var overlayCounter in sortedBadgeList) {
-        var overlayObject = sortedBadgeList[overlayCounter];
+  for (var overlayCounter in sortedBadgeList) {
+    var overlayObject = sortedBadgeList[overlayCounter];
 
-        if (overlayObject.badgeLocation === 'left') {
-            badges.push(overlays.add(element, 'badge', {
-                position: {
-                    bottom: 0,
-                    left: leftCounter
-                },
-                html: '<div class="prop-info ' + overlayObject.badgeBackground + '" data-badge="' + overlayObject.badgeType + '"></div>'
-            }));
-            leftCounter = leftCounter + 16;
-        } else {
-            badges.push(overlays.add(element, 'badge', {
-                position: {
-                    bottom: 0,
-                    right: rightCounter
-                },
-                html: '<div class="prop-info ' + overlayObject.badgeBackground + '" data-badge="' + overlayObject.badgeType + '"></div>'
-            }));
-            rightCounter = rightCounter + 16;
-        }
-
+    if (overlayObject.badgeLocation === 'left') {
+      badges.push(overlays.add(element, 'badge', {
+        position: {
+          bottom: 0,
+          left: leftCounter
+        },
+        html: '<div class="prop-info ' + overlayObject.badgeBackground + '" data-badge="' + overlayObject.badgeType + '"></div>'
+      }));
+      leftCounter = leftCounter + 16;
+    } else {
+      badges.push(overlays.add(element, 'badge', {
+        position: {
+          bottom: 0,
+          right: rightCounter
+        },
+        html: '<div class="prop-info ' + overlayObject.badgeBackground + '" data-badge="' + overlayObject.badgeType + '"></div>'
+      }));
+      rightCounter = rightCounter + 16;
     }
 
-    pushArray(elementOverlays[element.id],badges);
+  }
+
+  pushArray(elementOverlays[element.id], badges);
 }
 
 function uniqBy(a, key) {
-    var seen = {};
-    return a.filter(function (item) {
-        var k = key(item);
-        return seen.hasOwnProperty(k) ? false : (seen[k] = true);
-    })
+  var seen = {};
+  return a.filter(function (item) {
+    var k = key(item);
+    return seen.hasOwnProperty(k) ? false : (seen[k] = true);
+  })
 }
 
 function pushArray(list, other) {
-    var len = other.length;
-    var start = list.length;
-    list.length = start + len;
-    for (var i = 0; i < len; i++ , start++) {
-        list[start] = other[i];
-    }
+  var len = other.length;
+  var start = list.length;
+  list.length = start + len;
+  for (var i = 0; i < len; i++ , start++) {
+    list[start] = other[i];
+  }
 }

--- a/backend-diagram-converter/webapp/src/main/resources/static/lib/user-interaction.js
+++ b/backend-diagram-converter/webapp/src/main/resources/static/lib/user-interaction.js
@@ -10,135 +10,135 @@ const resultArea = document.getElementById("accordionExample");
 const arrangedResultsArea = document.getElementById("arrangedResults");
 
 const severityClasses = {
-    "WARNING": "text-bg-warning",
-    "INFO": "text-bg-secondary",
-    "TASK": "text-bg-info"
+  "WARNING": "text-bg-warning",
+  "INFO": "text-bg-secondary",
+  "TASK": "text-bg-info"
 }
 
 const el = (tagName, attributes, children) => {
-    const element = document.createElement(tagName);
-    Object.keys(attributes).forEach(key => element[key] = attributes[key]);
-    element.append(...children);
-    return element;
+  const element = document.createElement(tagName);
+  Object.keys(attributes).forEach(key => element[key] = attributes[key]);
+  element.append(...children);
+  return element;
 };
 
 const structureMessages = response => {
-    response.forEach(fileResponse => {
-        fileResponse.results.forEach(result => {
-            result.references.forEach(reference => {
-                fileResponse.results.filter(r => r.elementId === reference).forEach(r => {
-                    result.messages.push(...r.messages);
-                });
-            });
+  response.forEach(fileResponse => {
+    fileResponse.results.forEach(result => {
+      result.references.forEach(reference => {
+        fileResponse.results.filter(r => r.elementId === reference).forEach(r => {
+          result.messages.push(...r.messages);
         });
+      });
     });
+  });
 };
 
 const createFormattedResult = result => {
-    if (result.messages.length && result.referencedBy.length === 0) {
-        return el("div", {className: "card m-3"}, [
-            el("div", {className: "card-header"}, [result.elementType + " ", el("code", {}, result.elementId), ` ${result.elementName || ""}`]),
-            createFormattedMessages(result.messages)
-        ]);
-    }
+  if (result.messages.length && result.referencedBy.length === 0) {
+    return el("div", {className: "card m-3"}, [
+      el("div", {className: "card-header"}, [result.elementType + " ", el("code", {}, result.elementId), ` ${result.elementName || ""}`]),
+      createFormattedMessages(result.messages)
+    ]);
+  }
 };
 
 const createFormattedMessages = messages => {
-    return el("ul", {className: "list-group list-group-flush"}, messages.map(createFormattedMessage));
+  return el("ul", {className: "list-group list-group-flush"}, messages.map(createFormattedMessage));
 };
 
 const createFormattedMessage = message => {
-    return el("li", {className: `list-group-item ${severityClasses[message.severity]}`}, `${message.severity}: ${message.message}`);
+  return el("li", {className: `list-group-item ${severityClasses[message.severity]}`}, `${message.severity}: ${message.message}`);
 };
 
 const createFormData = async () => {
-    const formData = new FormData();
-    if (fileUpload.files.length === 0) {
-        alert("Please select a .bpmn file");
-        return null;
-    }
-    for (let i = 0; i < fileUpload.files.length; i++) {
-        formData.append("files", fileUpload.files[i], fileUpload.files[i].name)
-    }
-    formData.append("appendDocumentation", appendDocumentation.checked)
-    return formData;
+  const formData = new FormData();
+  if (fileUpload.files.length === 0) {
+    alert("Please select a .bpmn file");
+    return null;
+  }
+  for (let i = 0; i < fileUpload.files.length; i++) {
+    formData.append("files", fileUpload.files[i], fileUpload.files[i].name)
+  }
+  formData.append("appendDocumentation", appendDocumentation.checked)
+  return formData;
 }
 const createFormattedResultWrapper = files => {
-    arrangedResultsArea.append(...files.map(createFormattedResultForFile));
+  arrangedResultsArea.append(...files.map(createFormattedResultForFile));
 }
 
 const createFormattedResultForFile = file => {
-    return el("div", {className: "card mb-3"}, [
-        el("div", {className: "card-header"}, [file.filename]),
-        el("ul", {className: "list-group list-group-flush"}, file.results.map(createFormattedResult).filter(e => e !== undefined))
-    ]);
+  return el("div", {className: "card mb-3"}, [
+    el("div", {className: "card-header"}, [file.filename]),
+    el("ul", {className: "list-group list-group-flush"}, file.results.map(createFormattedResult).filter(e => e !== undefined))
+  ]);
 
 }
 
 const downloadResponse = async response => {
-    const contentDisposition = response.headers.get("Content-Disposition");
-    const targetFileName = contentDisposition.substring(contentDisposition.indexOf("\"") + 1, contentDisposition.lastIndexOf("\""));
-    response.blob().then(data => {
-        const a = document.createElement("a");
-        a.href = window.URL.createObjectURL(data);
-        a.download = targetFileName;
-        a.click();
-    });
+  const contentDisposition = response.headers.get("Content-Disposition");
+  const targetFileName = contentDisposition.substring(contentDisposition.indexOf("\"") + 1, contentDisposition.lastIndexOf("\""));
+  response.blob().then(data => {
+    const a = document.createElement("a");
+    a.href = window.URL.createObjectURL(data);
+    a.download = targetFileName;
+    a.click();
+  });
 };
 
 check.addEventListener("click", async () => {
-    const formData = await createFormData();
-    if (!formData) {
-        return;
+  const formData = await createFormData();
+  if (!formData) {
+    return;
+  }
+  fetch("/check", {
+    body: formData,
+    method: "POST",
+    headers: {
+      "Accept": "application/json"
     }
-    fetch("/check", {
-        body: formData,
-        method: "POST",
-        headers: {
-            "Accept": "application/json"
-        }
-    }).then(response => {
-        response.json().then(json => {
-            checkContainer.innerHTML = JSON.stringify(json, null, 2);
-            arrangedResultsArea.innerHTML = "";
-            structureMessages(json);
-            createFormattedResultWrapper(json);
-            resultArea.hidden = false;
-            addElementMarkers(json);
-        })
-    });
+  }).then(response => {
+    response.json().then(json => {
+      checkContainer.innerHTML = JSON.stringify(json, null, 2);
+      arrangedResultsArea.innerHTML = "";
+      structureMessages(json);
+      createFormattedResultWrapper(json);
+      resultArea.hidden = false;
+      addElementMarkers(json);
+    })
+  });
 });
 
 downloadCsv.addEventListener("click", async () => {
-    const formData = await createFormData();
-    if (!formData) {
-        return;
+  const formData = await createFormData();
+  if (!formData) {
+    return;
+  }
+  fetch("/check", {
+    body: formData,
+    method: "POST",
+    headers: {
+      "Accept": "text/csv"
     }
-    fetch("/check", {
-        body: formData,
-        method: "POST",
-        headers: {
-            "Accept": "text/csv"
-        }
-    }).then(downloadResponse);
+  }).then(downloadResponse);
 });
 
 convert.addEventListener("click", async () => {
-    const formData = await createFormData();
-    if (!formData) {
-        return;
-    }
-    fetch("/convert", {
-        body: formData,
-        method: "POST"
-    }).then(downloadResponse);
+  const formData = await createFormData();
+  if (!formData) {
+    return;
+  }
+  fetch("/convert", {
+    body: formData,
+    method: "POST"
+  }).then(downloadResponse);
 });
 
 async function showBpmn(bpmnXML) {
-    const bpmnViewer = await getBpmnViewer();
-    console.log('viewer loaded')
-    openDiagram(bpmnXML, bpmnViewer);
-    showPropertyInfos(bpmnViewer);
+  const bpmnViewer = await getBpmnViewer();
+  console.log('viewer loaded')
+  openDiagram(bpmnXML, bpmnViewer);
+  showPropertyInfos(bpmnViewer);
 }
 
 // load first diagram from uploaded files
@@ -146,32 +146,32 @@ const reader = new FileReader();
 reader.onload = showBpmn;
 
 if (fileUpload.files.length > 0) {
-    reader.readAsText(fileUpload.files[0]);
+  reader.readAsText(fileUpload.files[0]);
 }
 
 fileUpload.addEventListener("change", () => {
-    if (fileUpload.files.length !== 0) {
-        reader.readAsText(fileUpload.files[0]);
-    }
+  if (fileUpload.files.length !== 0) {
+    reader.readAsText(fileUpload.files[0]);
+  }
 });
 
 async function addElementMarkers(checkResult) {
-    const bpmnViewer = await getBpmnViewer();
-    var canvas = bpmnViewer.get('canvas');
-    checkResult[0].results.forEach(result => {
-        if (result.elementType !== 'process' && result.elementType !== 'message') {
-            if (result.messages.length > 0) {
-                const isWarning = result.messages.some(message => message.severity === 'WARNING');
-                const isTask = result.messages.some(message => message.severity === 'TASK');
-                if (isWarning) {
-                    console.log('marker for ', result.elementId, result.elementName, 'WARNING');
-                    canvas.addMarker(result.elementId, 'conversion-warning')
-                } else if (isTask) {
-                    console.log('marker for ', result.elementId, result.elementName, 'WARNING');
-                    canvas.addMarker(result.elementId, 'conversion-task')
-                }
-            }
-
+  const bpmnViewer = await getBpmnViewer();
+  var canvas = bpmnViewer.get('canvas');
+  checkResult[0].results.forEach(result => {
+    if (result.elementType !== 'process' && result.elementType !== 'message') {
+      if (result.messages.length > 0) {
+        const isWarning = result.messages.some(message => message.severity === 'WARNING');
+        const isTask = result.messages.some(message => message.severity === 'TASK');
+        if (isWarning) {
+          console.log('marker for ', result.elementId, result.elementName, 'WARNING');
+          canvas.addMarker(result.elementId, 'conversion-warning')
+        } else if (isTask) {
+          console.log('marker for ', result.elementId, result.elementName, 'WARNING');
+          canvas.addMarker(result.elementId, 'conversion-task')
         }
-    })
+      }
+
+    }
+  })
 }

--- a/backend-diagram-converter/webapp/src/test/java/org/camunda/community/migration/converter/webapp/ConverterControllerTest.java
+++ b/backend-diagram-converter/webapp/src/test/java/org/camunda/community/migration/converter/webapp/ConverterControllerTest.java
@@ -35,7 +35,7 @@ public class ConverterControllerTest {
             .multiPart(
                 "files", new File(getClass().getClassLoader().getResource("example.bpmn").toURI()))
             .accept(ContentType.JSON)
-            .post("http://localhost:8080/check")
+            .post("http://localhost:18080/check")
             .getBody()
             .as(new TypeRef<List<BpmnDiagramCheckResult>>() {});
     assertThat(checkResult).hasSize(1);
@@ -53,7 +53,7 @@ public class ConverterControllerTest {
             .multiPart(
                 "files", new File(getClass().getClassLoader().getResource("example.bpmn").toURI()))
             .accept("text/csv")
-            .post("http://localhost:8080/check")
+            .post("http://localhost:18080/check")
             .getBody()
             .print();
     try (CSVReader reader =
@@ -75,7 +75,7 @@ public class ConverterControllerTest {
             .multiPart(
                 "files", new File(getClass().getClassLoader().getResource("example.bpmn").toURI()))
             .accept("text/csv")
-            .post("http://localhost:8080/convert")
+            .post("http://localhost:18080/convert")
             .getBody()
             .asByteArray();
     try (ZipInputStream inputStream = new ZipInputStream(new ByteArrayInputStream(zip))) {

--- a/backend-diagram-converter/webapp/src/test/java/org/camunda/community/migration/converter/webapp/ConverterControllerTest.java
+++ b/backend-diagram-converter/webapp/src/test/java/org/camunda/community/migration/converter/webapp/ConverterControllerTest.java
@@ -20,12 +20,20 @@ import java.util.List;
 import java.util.zip.ZipInputStream;
 import org.camunda.bpm.model.xml.instance.DomElement;
 import org.camunda.community.migration.converter.BpmnDiagramCheckResult;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
 
-@SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 public class ConverterControllerTest {
+  @LocalServerPort int port;
+
+  @BeforeEach
+  void setup() {
+    RestAssured.port = port;
+  }
 
   @Test
   void shouldReturnCheckResult() throws URISyntaxException {
@@ -35,7 +43,7 @@ public class ConverterControllerTest {
             .multiPart(
                 "files", new File(getClass().getClassLoader().getResource("example.bpmn").toURI()))
             .accept(ContentType.JSON)
-            .post("http://localhost:18080/check")
+            .post("/check")
             .getBody()
             .as(new TypeRef<List<BpmnDiagramCheckResult>>() {});
     assertThat(checkResult).hasSize(1);
@@ -53,7 +61,7 @@ public class ConverterControllerTest {
             .multiPart(
                 "files", new File(getClass().getClassLoader().getResource("example.bpmn").toURI()))
             .accept("text/csv")
-            .post("http://localhost:18080/check")
+            .post("/check")
             .getBody()
             .print();
     try (CSVReader reader =
@@ -75,7 +83,7 @@ public class ConverterControllerTest {
             .multiPart(
                 "files", new File(getClass().getClassLoader().getResource("example.bpmn").toURI()))
             .accept("text/csv")
-            .post("http://localhost:18080/convert")
+            .post("/convert")
             .getBody()
             .asByteArray();
     try (ZipInputStream inputStream = new ZipInputStream(new ByteArrayInputStream(zip))) {

--- a/backend-diagram-converter/webapp/src/test/resources/application.yaml
+++ b/backend-diagram-converter/webapp/src/test/resources/application.yaml
@@ -1,1 +1,0 @@
-server.port: 18080

--- a/backend-diagram-converter/webapp/src/test/resources/application.yaml
+++ b/backend-diagram-converter/webapp/src/test/resources/application.yaml
@@ -1,0 +1,1 @@
+server.port: 18080


### PR DESCRIPTION
## Description
Currently, every element is handled "standalone", meaning there is no relation between them displayed in the check results.

This leads to "invisible" messages for events ("bpmn:message", ...) as they are not part of the process diectly, but they are referenced from other elements.

This PR provides additional context to resolve this.

The messages will stay where they belong, but there will be 2-way references between elements.

For displaying the result, this means that any message from any referenced element will be shown on the element referring to it.

## Additional context
Closes #131 

## Testing your changes
There is a new unit test in placce that asserts the reference is defined correctly.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an existing open issue)
- [x] New feature (non-breaking change which adds functionality to an extension)
- [ ] Breaking change (fix or feature that would cause existing functionality of an extension to change)
- [ ] Documentation update (changes made to an existing piece of documentation)

## Checklist:
- [x] My code adheres to the syntax used by this extension.
- [x] My pull request requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **Camunda Community Hub** documentation.
- [x] I have read the **Pull Request Process** documentation.
- [x] I have added or suggested tests to cover my changes suggested in this pull request.
- [x] All new and existing CI/CD tests passed.
- [x] I will /assign myself this issue, and add the relevant [issue labels] to it if they are not automatically generated by Probot.
- [x] I will tag @camunda-community-hub/devrel in a new comment on this issue if 30 days have passed since my pull request was opened and I have not received a response from the extension's maintainer.
