### PR TITLE
Reframed execution listener message

### DIFF
--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/message/MessageFactory.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/message/MessageFactory.java
@@ -256,10 +256,13 @@ public class MessageFactory {
             .build());
   }
 
-  public static Message executionListener(String elementLocalName) {
+  public static Message executionListener(String event, String implementation) {
     return INSTANCE.composeMessage(
         "execution-listener",
-        ContextBuilder.builder().context(elementNotTransformablePrefix(elementLocalName)).build());
+        ContextBuilder.builder()
+            .entry("event", event)
+            .entry("implementation", implementation)
+            .build());
   }
 
   public static Message resultVariableBusinessRule(
@@ -335,10 +338,13 @@ public class MessageFactory {
         ContextBuilder.builder().context(elementNotTransformablePrefix(elementLocalName)).build());
   }
 
-  public static Message taskListener(String listenerImplementation) {
+  public static Message taskListener(String event, String implementation) {
     return INSTANCE.composeMessage(
         "task-listener",
-        ContextBuilder.builder().entry("implementation", listenerImplementation).build());
+        ContextBuilder.builder()
+            .entry("event", event)
+            .entry("implementation", implementation)
+            .build());
   }
 
   public static Message formData(String elementLocalName) {

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/AbstractListenerVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/AbstractListenerVisitor.java
@@ -1,0 +1,38 @@
+package org.camunda.community.migration.converter.visitor;
+
+import org.camunda.community.migration.converter.DomElementVisitorContext;
+import org.camunda.community.migration.converter.NamespaceUri;
+import org.camunda.community.migration.converter.message.Message;
+
+public abstract class AbstractListenerVisitor extends AbstractCamundaElementVisitor {
+
+  @Override
+  protected final Message visitCamundaElement(DomElementVisitorContext context) {
+    String implementation = findListenerImplementation(context);
+    String event = context.getElement().getAttribute(NamespaceUri.CAMUNDA, "event");
+    return visitListener(context, event, implementation);
+  }
+
+  protected abstract Message visitListener(
+      DomElementVisitorContext context, String event, String implementation);
+
+  private String findListenerImplementation(DomElementVisitorContext context) {
+    String listenerImplementation = context.getElement().getAttribute("delegateExpression");
+    if (listenerImplementation == null) {
+      listenerImplementation = context.getElement().getAttribute("class");
+    }
+    if (listenerImplementation == null) {
+      listenerImplementation = context.getElement().getAttribute("expression");
+    }
+    if (listenerImplementation == null
+        && context.getElement().getChildElementsByNameNs(NamespaceUri.CAMUNDA, "script") != null) {
+      listenerImplementation =
+          context
+              .getElement()
+              .getChildElementsByNameNs(NamespaceUri.CAMUNDA, "script")
+              .get(0)
+              .getAttribute("scriptFormat");
+    }
+    return listenerImplementation;
+  }
+}

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/element/ExecutionListenerVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/element/ExecutionListenerVisitor.java
@@ -3,17 +3,18 @@ package org.camunda.community.migration.converter.visitor.impl.element;
 import org.camunda.community.migration.converter.DomElementVisitorContext;
 import org.camunda.community.migration.converter.message.Message;
 import org.camunda.community.migration.converter.message.MessageFactory;
-import org.camunda.community.migration.converter.visitor.AbstractCamundaElementVisitor;
+import org.camunda.community.migration.converter.visitor.AbstractListenerVisitor;
 
-public class ExecutionListenerVisitor extends AbstractCamundaElementVisitor {
+public class ExecutionListenerVisitor extends AbstractListenerVisitor {
   @Override
   public String localName() {
     return "executionListener";
   }
 
   @Override
-  protected Message visitCamundaElement(DomElementVisitorContext context) {
-    return MessageFactory.executionListener(context.getElement().getLocalName());
+  protected Message visitListener(
+      DomElementVisitorContext context, String event, String implementation) {
+    return MessageFactory.executionListener(event, implementation);
   }
 
   @Override

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/element/TaskListenerVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/element/TaskListenerVisitor.java
@@ -1,41 +1,20 @@
 package org.camunda.community.migration.converter.visitor.impl.element;
 
 import org.camunda.community.migration.converter.DomElementVisitorContext;
-import org.camunda.community.migration.converter.NamespaceUri;
 import org.camunda.community.migration.converter.message.Message;
 import org.camunda.community.migration.converter.message.MessageFactory;
-import org.camunda.community.migration.converter.visitor.AbstractCamundaElementVisitor;
+import org.camunda.community.migration.converter.visitor.AbstractListenerVisitor;
 
-public class TaskListenerVisitor extends AbstractCamundaElementVisitor {
+public class TaskListenerVisitor extends AbstractListenerVisitor {
   @Override
   public String localName() {
     return "taskListener";
   }
 
   @Override
-  protected Message visitCamundaElement(DomElementVisitorContext context) {
-    String listenerImplementation = findListenerImplementation(context);
-    return MessageFactory.taskListener(listenerImplementation);
-  }
-
-  protected String findListenerImplementation(DomElementVisitorContext context) {
-    String listenerImplementation = context.getElement().getAttribute("delegateExpression");
-    if (listenerImplementation == null) {
-      listenerImplementation = context.getElement().getAttribute("class");
-    }
-    if (listenerImplementation == null) {
-      listenerImplementation = context.getElement().getAttribute("expression");
-    }
-    if (listenerImplementation == null
-        && context.getElement().getChildElementsByNameNs(NamespaceUri.CAMUNDA, "script") != null) {
-      listenerImplementation =
-          context
-              .getElement()
-              .getChildElementsByNameNs(NamespaceUri.CAMUNDA, "script")
-              .get(0)
-              .getAttribute("scriptFormat");
-    }
-    return listenerImplementation;
+  protected Message visitListener(
+      DomElementVisitorContext context, String event, String implementation) {
+    return MessageFactory.taskListener(event, implementation);
   }
 
   @Override

--- a/backend-diagram-converter/core/src/main/resources/message-templates.properties
+++ b/backend-diagram-converter/core/src/main/resources/message-templates.properties
@@ -110,10 +110,10 @@ connector-id.severity=TASK
 property.message={{ templates.element-transformed-prefix }} Property '{{ propertyName}}' lives in the Zeebe namespace now.
 property.severity=INFO
 #
-execution-listener.message={{ templates.element-not-transformable-prefix }} Execution Listeners do not exist in Zeebe.
+execution-listener.message=Listener at '{{ event }}' with implementation '{{ implementation }}' cannot be transformed. Execution Listeners do not exist in Zeebe.
 execution-listener.severity=WARNING
 #
-task-listener.message=Element 'taskListener' with implementation '{{ implementation }}' cannot be transformed. Task Listeners do not exist in Zeebe.
+task-listener.message=Listener at '{{ event }}' with implementation '{{ implementation }}' cannot be transformed. Task Listeners do not exist in Zeebe.
 task-listener.severity=WARNING
 #
 failed-job-retry-time-cycle.message={{ templates.element-transformed-prefix }} The timecycle '{{ timecycle }}' was transformed to '{{ retries }}' retries. Please review. Please keep in mind that the timeout '{{ timeout }}' between the retries has to be defined by your worker implementation.

--- a/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/BpmnConverterTest.java
+++ b/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/BpmnConverterTest.java
@@ -82,26 +82,26 @@ public class BpmnConverterTest {
     assertThat(javaClassCheckResult.getMessages()).hasSize(1);
     assertThat(javaClassCheckResult.getMessages().get(0).getMessage())
         .isEqualTo(
-            "Element 'taskListener' with implementation 'com.camunda.consulting.TaskListenerExample' cannot be transformed. Task Listeners do not exist in Zeebe.");
+            "Listener at 'create' with implementation 'com.camunda.consulting.TaskListenerExample' cannot be transformed. Task Listeners do not exist in Zeebe.");
 
     BpmnElementCheckResult delegateExpressionCheckResult =
         result.getResult("UserTaskUseDelegateExpression");
     assertThat(delegateExpressionCheckResult.getMessages()).hasSize(1);
     assertThat(delegateExpressionCheckResult.getMessages().get(0).getMessage())
         .isEqualTo(
-            "Element 'taskListener' with implementation '${taskListenerExample}' cannot be transformed. Task Listeners do not exist in Zeebe.");
+            "Listener at 'assignment' with implementation '${taskListenerExample}' cannot be transformed. Task Listeners do not exist in Zeebe.");
 
     BpmnElementCheckResult expressionCheckResult = result.getResult("UserTaskUseExpression");
     assertThat(expressionCheckResult.getMessages()).hasSize(1);
     assertThat(expressionCheckResult.getMessages().get(0).getMessage())
         .isEqualTo(
-            "Element 'taskListener' with implementation '${delegateTask.setName(\"my expression name\")}' cannot be transformed. Task Listeners do not exist in Zeebe.");
+            "Listener at 'complete' with implementation '${delegateTask.setName(\"my expression name\")}' cannot be transformed. Task Listeners do not exist in Zeebe.");
 
     BpmnElementCheckResult inlineScriptCheckResult = result.getResult("UserTaskUseInlineScript");
     assertThat(inlineScriptCheckResult.getMessages()).hasSize(2);
     assertThat(inlineScriptCheckResult.getMessages().get(0).getMessage())
         .isEqualTo(
-            "Element 'taskListener' with implementation 'javascript' cannot be transformed. Task Listeners do not exist in Zeebe.");
+            "Listener at 'delete' with implementation 'javascript' cannot be transformed. Task Listeners do not exist in Zeebe.");
     assertThat(inlineScriptCheckResult.getMessages().get(1).getMessage())
         .isEqualTo(
             "Element 'script' cannot be transformed. Script 'delegateTask.setName(\"my script name\");' with format 'javascript' on 'taskListener'.");
@@ -185,6 +185,30 @@ public class BpmnConverterTest {
     assertThat(message).isNotNull();
     assertThat(message.getReferencedBy()).hasSize(1);
     assertThat(message.getReferencedBy().get(0)).isEqualTo("Receive1Task");
+  }
+
+  @Test
+  void testExecutionListener() {
+    BpmnDiagramCheckResult result = loadAndCheck("execution-listener.bpmn");
+    BpmnElementCheckResult serviceTaskWithListenerTask =
+        result.getResult("ServiceTaskWithListenerTask");
+    assertThat(serviceTaskWithListenerTask).isNotNull();
+    assertThat(serviceTaskWithListenerTask.getMessages()).hasSize(7);
+    assertThat(serviceTaskWithListenerTask.getMessages().get(0).getMessage())
+        .isEqualTo(
+            "Listener at 'end' with implementation '${endListener.execute(something)}' cannot be transformed. Execution Listeners do not exist in Zeebe.");
+    assertThat(serviceTaskWithListenerTask.getMessages().get(1).getMessage())
+        .isEqualTo(
+            "Listener at 'start' with implementation '${anotherStartListener}' cannot be transformed. Execution Listeners do not exist in Zeebe.");
+    assertThat(serviceTaskWithListenerTask.getMessages().get(2).getMessage())
+        .isEqualTo(
+            "Listener at 'end' with implementation 'groovy' cannot be transformed. Execution Listeners do not exist in Zeebe.");
+    assertThat(serviceTaskWithListenerTask.getMessages().get(3).getMessage())
+        .isEqualTo(
+            "Element 'script' cannot be transformed. Script 'print(\"something\");' with format 'groovy' on 'executionListener'.");
+    assertThat(serviceTaskWithListenerTask.getMessages().get(4).getMessage())
+        .isEqualTo(
+            "Listener at 'start' with implementation 'com.example.StartListener' cannot be transformed. Execution Listeners do not exist in Zeebe.");
   }
 
   protected BpmnDiagramCheckResult loadAndCheck(String bpmnFile) {

--- a/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/message/MessageFactoryTest.java
+++ b/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/message/MessageFactoryTest.java
@@ -269,11 +269,11 @@ public class MessageFactoryTest {
 
   @Test
   void shouldBuildTaskListener() {
-    Message message = MessageFactory.taskListener("my tasklistener implementation");
+    Message message = MessageFactory.taskListener("create", "my tasklistener implementation");
     assertNotNull(message);
     assertThat(message.getMessage())
         .isEqualTo(
-            "Element 'taskListener' with implementation 'my tasklistener implementation' cannot be transformed. Task Listeners do not exist in Zeebe.");
+            "Listener at 'create' with implementation 'my tasklistener implementation' cannot be transformed. Task Listeners do not exist in Zeebe.");
   }
 
   @Test
@@ -352,9 +352,12 @@ public class MessageFactoryTest {
 
   @Test
   void shouldBuildExecutionListener() {
-    Message message = MessageFactory.executionListener(random());
+    Message message = MessageFactory.executionListener("start", "${myExecutionListener}");
     assertNotNull(message);
     assertNotNull(message.getMessage());
+    assertThat(message.getMessage())
+        .isEqualTo(
+            "Listener at 'start' with implementation '${myExecutionListener}' cannot be transformed. Execution Listeners do not exist in Zeebe.");
   }
 
   @Test

--- a/backend-diagram-converter/core/src/test/resources/execution-listener.bpmn
+++ b/backend-diagram-converter/core/src/test/resources/execution-listener.bpmn
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0z01aa9" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.5.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.18.0">
+  <bpmn:process id="ExecutionListenerExampleProcess" name="Execution Listener Example" isExecutable="true">
+    <bpmn:startEvent id="ProcessStartedStartEvent" name="Process started">
+      <bpmn:outgoing>Flow_062ylxt</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_062ylxt" sourceRef="ProcessStartedStartEvent" targetRef="ServiceTaskWithListenerTask" />
+    <bpmn:endEvent id="ProcessEndedEndEvent" name="Process ended">
+      <bpmn:incoming>Flow_11p4hxx</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_11p4hxx" sourceRef="ServiceTaskWithListenerTask" targetRef="ProcessEndedEndEvent" />
+    <bpmn:serviceTask id="ServiceTaskWithListenerTask" name="Service task with listener" camunda:expression="${service.call(myVariable)}" camunda:resultVariable="myResult">
+      <bpmn:extensionElements>
+        <camunda:executionListener expression="${endListener.execute(something)}" event="end" />
+        <camunda:executionListener delegateExpression="${anotherStartListener}" event="start" />
+        <camunda:executionListener event="end">
+          <camunda:script scriptFormat="groovy">print("something");</camunda:script>
+        </camunda:executionListener>
+        <camunda:executionListener class="com.example.StartListener" event="start" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_062ylxt</bpmn:incoming>
+      <bpmn:outgoing>Flow_11p4hxx</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="ExecutionListenerExampleProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="ProcessStartedStartEvent">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="159" y="142" width="77" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1m8cvx9_di" bpmnElement="ProcessEndedEndEvent">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="413" y="142" width="74" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1d5o5rh_di" bpmnElement="ServiceTaskWithListenerTask">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_062ylxt_di" bpmnElement="Flow_062ylxt">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_11p4hxx_di" bpmnElement="Flow_11p4hxx">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/backend-diagram-converter/core/src/test/resources/user-task-listener-implementations.bpmn
+++ b/backend-diagram-converter/core/src/test/resources/user-task-listener-implementations.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1rh4xjp" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.5.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.18.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1rh4xjp" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.5.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.18.0">
   <bpmn:process id="UserTaskListenerImplementationsProcess" name="User Task Listener Implementations" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="All task listener implementations wanted">
       <bpmn:outgoing>Flow_03ety8g</bpmn:outgoing>
@@ -15,7 +15,7 @@
     <bpmn:sequenceFlow id="Flow_0rxm0x2" sourceRef="UserTaskUseJavaClass" targetRef="UserTaskUseDelegateExpression" />
     <bpmn:userTask id="UserTaskUseDelegateExpression" name="Use delegate expression">
       <bpmn:extensionElements>
-        <camunda:taskListener delegateExpression="${taskListenerExample}" event="create" />
+        <camunda:taskListener delegateExpression="${taskListenerExample}" event="assignment" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0rxm0x2</bpmn:incoming>
       <bpmn:outgoing>Flow_1wzinyc</bpmn:outgoing>
@@ -23,7 +23,7 @@
     <bpmn:sequenceFlow id="Flow_1wzinyc" sourceRef="UserTaskUseDelegateExpression" targetRef="UserTaskUseExpression" />
     <bpmn:userTask id="UserTaskUseExpression" name="Use expression">
       <bpmn:extensionElements>
-        <camunda:taskListener expression="${delegateTask.setName(&#34;my expression name&#34;)}" event="create" />
+        <camunda:taskListener expression="${delegateTask.setName(&#34;my expression name&#34;)}" event="complete" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1wzinyc</bpmn:incoming>
       <bpmn:outgoing>Flow_0e1l4oq</bpmn:outgoing>
@@ -31,7 +31,7 @@
     <bpmn:sequenceFlow id="Flow_0e1l4oq" sourceRef="UserTaskUseExpression" targetRef="UserTaskUseInlineScript" />
     <bpmn:userTask id="UserTaskUseInlineScript" name="Use inline script">
       <bpmn:extensionElements>
-        <camunda:taskListener event="create">
+        <camunda:taskListener event="delete">
           <camunda:script scriptFormat="javascript">delegateTask.setName("my script name");</camunda:script>
         </camunda:taskListener>
       </bpmn:extensionElements>


### PR DESCRIPTION
## Description
The execution listener now has also a meaningful message

## Additional context
Closes #135 

## Testing your changes
There is a unit test in place

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an existing open issue)
- [x] New feature (non-breaking change which adds functionality to an extension)
- [ ] Breaking change (fix or feature that would cause existing functionality of an extension to change)
- [ ] Documentation update (changes made to an existing piece of documentation)

## Checklist:
- [x] My code adheres to the syntax used by this extension.
- [x] My pull request requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **Camunda Community Hub** documentation.
- [x] I have read the **Pull Request Process** documentation.
- [x] I have added or suggested tests to cover my changes suggested in this pull request.
- [x] All new and existing CI/CD tests passed.
- [x] I will /assign myself this issue, and add the relevant [issue labels] to it if they are not automatically generated by Probot.
- [x] I will tag @camunda-community-hub/devrel in a new comment on this issue if 30 days have passed since my pull request was opened and I have not received a response from the extension's maintainer.
