### PR TITLE
Feature: Webapp can only handle single-file uploads

### DIFF
--- a/backend-diagram-converter/webapp/README.md
+++ b/backend-diagram-converter/webapp/README.md
@@ -21,25 +21,25 @@ The API offers 2 methods:
 * Request:
   * Format: `FormData`
   * Fields
-    * `files` (`MultipartFile[]`): BPMN files _(mandatory)_
+    * `file` (`MultipartFile`): BPMN file _(mandatory)_
     * `adapterJobType` (`String`): type of the job all service tasks formerly implemented as delegates or expressions should have. _(optional)_
     * `platformVersion` (`String`): version of the target platform _(optional)_
   * Headers
     * `Accept`: Either `application/json` or `text/csv`
 * Response:
-  * `200`: Everything fine. The body contains a list of [check results](../core/src/main/java/org/camunda/community/migration/converter/BpmnDiagramCheckResult.java), either in `application/json` format or flattened as `text/csv`.
+  * `200`: Everything fine. The body contains a [check results](../core/src/main/java/org/camunda/community/migration/converter/BpmnDiagramCheckResult.java), either in `application/json` format or flattened as `text/csv`.
 
 `POST /convert`:
 
 * Request:
   * Format: `FormData`
   * Fields
-    * `files` (`MultipartFile[]`): BPMN files _(mandatory)_
+    * `file` (`MultipartFile`): BPMN file _(mandatory)_
     * `appendDocumentation` (`Boolean`): whether the check results should also be added to the documentation of each BPMN element _(default: `false`)_
     * `adapterJobType` (`String`): type of the job all service tasks formerly implemented as delegates or expressions should have. _(optional)_
     * `platformVersion` (`String`): version of the target platform _(optional)_
 * Response:
-  * `200`: Everything fine. The body contains a zipped `Blob` which can be saved as a file and is a zip archive containing your converted BPMN diagrams.
+  * `200`: Everything fine. The body contains a BPMN diagram. The header contains a `Content-Disposition` field that declares this as attachment and holds a filename. The `Content-Type` is `application/bpmn+xml`.
 
 These error can occur on both endpoints:
 

--- a/backend-diagram-converter/webapp/src/main/java/org/camunda/community/migration/converter/webapp/ConverterController.java
+++ b/backend-diagram-converter/webapp/src/main/java/org/camunda/community/migration/converter/webapp/ConverterController.java
@@ -1,20 +1,15 @@
 package org.camunda.community.migration.converter.webapp;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
-import java.util.AbstractMap.SimpleEntry;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
+import java.util.Collections;
 import org.camunda.bpm.model.bpmn.Bpmn;
 import org.camunda.bpm.model.bpmn.BpmnModelInstance;
 import org.camunda.community.migration.converter.BpmnDiagramCheckResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
@@ -29,6 +24,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 public class ConverterController {
+  private static final Logger LOG = LoggerFactory.getLogger(ConverterController.class);
   private final BpmnConverterService bpmnConverter;
   private final CsvWriterService csvWriterService;
 
@@ -44,85 +40,66 @@ public class ConverterController {
       produces = {MediaType.APPLICATION_JSON_VALUE, "text/csv"},
       consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
   public ResponseEntity<?> check(
-      @RequestParam("files") MultipartFile[] bpmnFiles,
+      @RequestParam("file") MultipartFile bpmnFile,
       @RequestParam(value = "adapterJobType", required = false) String adapterJobType,
       @RequestParam(value = "platformVersion", required = false) String platformVersion,
       @RequestHeader(HttpHeaders.ACCEPT) String[] contentType) {
-    List<BpmnDiagramCheckResult> results =
-        Arrays.stream(bpmnFiles)
-            .map(
-                bpmnFile -> {
-                  try (InputStream in = bpmnFile.getInputStream()) {
-                    return bpmnConverter.check(
-                        bpmnFile.getOriginalFilename(),
-                        Bpmn.readModelFromStream(in),
-                        false,
-                        adapterJobType,
-                        platformVersion);
-                  } catch (IOException e) {
-                    BpmnDiagramCheckResult result = new BpmnDiagramCheckResult();
-                    result.setFilename(bpmnFile.getOriginalFilename());
-                    return result;
-                  }
-                })
-            .collect(Collectors.toList());
-    if (contentType == null
-        || contentType.length == 0
-        || Arrays.asList(contentType).contains(MediaType.APPLICATION_JSON_VALUE)) {
-      return ResponseEntity.ok(results);
-    }
-    if (Arrays.asList(contentType).contains("text/csv")) {
-      StringWriter sw = new StringWriter();
-      csvWriterService.writeCsvFile(results, sw);
-      Resource file = new ByteArrayResource(sw.toString().getBytes());
-      return ResponseEntity.ok()
-          .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"conversionResult.csv\"")
-          .contentType(MediaType.APPLICATION_OCTET_STREAM)
-          .body(file);
-    } else {
-      return ResponseEntity.badRequest().build();
+
+    try (InputStream in = bpmnFile.getInputStream()) {
+      BpmnDiagramCheckResult diagramCheckResult =
+          bpmnConverter.check(
+              bpmnFile.getOriginalFilename(),
+              Bpmn.readModelFromStream(in),
+              false,
+              adapterJobType,
+              platformVersion);
+      if (contentType == null
+          || contentType.length == 0
+          || Arrays.asList(contentType).contains(MediaType.APPLICATION_JSON_VALUE)) {
+        return ResponseEntity.ok(diagramCheckResult);
+      }
+      if (Arrays.asList(contentType).contains("text/csv")) {
+        StringWriter sw = new StringWriter();
+        csvWriterService.writeCsvFile(Collections.singletonList(diagramCheckResult), sw);
+        Resource file = new ByteArrayResource(sw.toString().getBytes());
+        return ResponseEntity.ok()
+            .header(
+                HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"conversionResult.csv\"")
+            .contentType(MediaType.APPLICATION_OCTET_STREAM)
+            .body(file);
+      } else {
+        return ResponseEntity.badRequest().build();
+      }
+    } catch (IOException e) {
+      LOG.error("Error while reading input stream of BPMN file", e);
+      return ResponseEntity.badRequest().body(e.getMessage());
     }
   }
 
   @PostMapping(
       value = "/convert",
-      produces = {MediaType.APPLICATION_OCTET_STREAM_VALUE},
+      produces = {"application/bpmn+xml"},
       consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
   public ResponseEntity<?> getFile(
-      @RequestParam("files") MultipartFile[] bpmnFiles,
+      @RequestParam("file") MultipartFile bpmnFile,
       @RequestParam("appendDocumentation") boolean appendDocumentation,
       @RequestParam(value = "adapterJobType", required = false) String adapterJobType,
       @RequestParam(value = "platformVersion", required = false) String platformVersion) {
-    Map<MultipartFile, Exception> exceptions = new HashMap<>();
-    ByteArrayOutputStream bo = new ByteArrayOutputStream();
-    try (ZipOutputStream out = new ZipOutputStream(bo)) {
-      for (MultipartFile bpmnFile : bpmnFiles) {
-        try (InputStream in = bpmnFile.getInputStream()) {
-          BpmnModelInstance modelInstance = Bpmn.readModelFromStream(in);
-          bpmnConverter.convert(
-              modelInstance, appendDocumentation, adapterJobType, platformVersion);
-          ZipEntry entry = new ZipEntry("converted-c8-" + bpmnFile.getOriginalFilename());
-          out.putNextEntry(entry);
-          out.write(bpmnConverter.printXml(modelInstance.getDocument(), true).getBytes());
-        } catch (Exception e) {
-          exceptions.put(bpmnFile, e);
-        }
-      }
-    } catch (IOException e) {
-      return ResponseEntity.internalServerError().body(e.getMessage());
-    }
-    if (exceptions.isEmpty()) {
-      Resource file = new ByteArrayResource(bo.toByteArray());
+    try (InputStream in = bpmnFile.getInputStream()) {
+      BpmnModelInstance modelInstance = Bpmn.readModelFromStream(in);
+      bpmnConverter.convert(modelInstance, appendDocumentation, adapterJobType, platformVersion);
+      String bpmnXml = bpmnConverter.printXml(modelInstance.getDocument(), true);
+      Resource file = new ByteArrayResource(bpmnXml.getBytes());
       return ResponseEntity.ok()
-          .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"conversionResult.zip\"")
-          .contentType(MediaType.APPLICATION_OCTET_STREAM)
+          .header(
+              HttpHeaders.CONTENT_DISPOSITION,
+              "attachment; filename=\"converted-c8-" + bpmnFile.getOriginalFilename() + "\"")
+          .header(HttpHeaders.CONTENT_TYPE, "application/bpmn+xml")
           .body(file);
-    } else {
-      return ResponseEntity.badRequest()
-          .body(
-              exceptions.entrySet().stream()
-                  .map(e -> new SimpleEntry<>(e.getKey().getOriginalFilename(), e.getValue()))
-                  .collect(Collectors.toList()));
+    } catch (IOException e) {
+      return ResponseEntity.badRequest().body(e.getMessage());
+    } catch (Exception e) {
+      return ResponseEntity.internalServerError().body(e.getMessage());
     }
   }
 }

--- a/backend-diagram-converter/webapp/src/main/resources/static/index.html
+++ b/backend-diagram-converter/webapp/src/main/resources/static/index.html
@@ -10,12 +10,12 @@
 
     <!-- required viewer styles -->
     <link rel="stylesheet" href="https://unpkg.com/bpmn-js@10.2.1/dist/assets/bpmn-js.css">
-    
+
     <link rel="stylesheet" href="styles/viewer.css">
 
     <!-- viewer distro (with pan and zoom) -->
     <script src="https://unpkg.com/bpmn-js@10.2.1/dist/bpmn-navigated-viewer.development.js"></script>
-<!--     <script src="https://unpkg.com/bpmn-js@10.2.1/dist/bpmn-modeler.development.js"> -->
+    <!--     <script src="https://unpkg.com/bpmn-js@10.2.1/dist/bpmn-modeler.development.js"> -->
 
     <!-- needed for this example only -->
     <script src="https://unpkg.com/jquery@3.3.1/dist/jquery.js"></script>
@@ -39,8 +39,8 @@
     </div>
     <div class="row">
         <div class="mb-3">
-            <label for="formFile" class="form-label">Camunda 7 BPMN files</label>
-            <input class="form-control" type="file" id="formFile" multiple>
+            <label for="formFile" class="form-label">Camunda 7 BPMN file</label>
+            <input class="form-control" type="file" id="formFile">
         </div>
         <div class="mb-3">
             <input class="form-check-input" type="checkbox" id="appendDocumentation">
@@ -56,7 +56,7 @@
     </div>
     <div class="row">
         <div class="mb-3">
-            <div id="canvas"></div>        
+            <div id="canvas"></div>
         </div>
     </div>
     <div class="accordion" id="accordionExample" hidden>

--- a/backend-diagram-converter/webapp/src/main/resources/static/lib/user-interaction.js
+++ b/backend-diagram-converter/webapp/src/main/resources/static/lib/user-interaction.js
@@ -24,12 +24,10 @@ const el = (tagName, attributes, children) => {
 };
 
 const structureMessages = response => {
-  response.forEach(fileResponse => {
-    fileResponse.results.forEach(result => {
-      result.references.forEach(reference => {
-        fileResponse.results.filter(r => r.elementId === reference).forEach(r => {
-          result.messages.push(...r.messages);
-        });
+  response.results.forEach(result => {
+    result.references.forEach(reference => {
+      response.results.filter(r => r.elementId === reference).forEach(r => {
+        result.messages.push(...r.messages);
       });
     });
   });
@@ -58,21 +56,16 @@ const createFormData = async () => {
     alert("Please select a .bpmn file");
     return null;
   }
-  for (let i = 0; i < fileUpload.files.length; i++) {
-    formData.append("files", fileUpload.files[i], fileUpload.files[i].name)
-  }
+  formData.append("file", fileUpload.files[0]);
   formData.append("appendDocumentation", appendDocumentation.checked)
   return formData;
 }
-const createFormattedResultWrapper = files => {
-  arrangedResultsArea.append(...files.map(createFormattedResultForFile));
+const createFormattedResultWrapper = file => {
+  arrangedResultsArea.append(...createFormattedResultForFile(file));
 }
 
 const createFormattedResultForFile = file => {
-  return el("div", {className: "card mb-3"}, [
-    el("div", {className: "card-header"}, [file.filename]),
-    el("ul", {className: "list-group list-group-flush"}, file.results.map(createFormattedResult).filter(e => e !== undefined))
-  ]);
+  return  file.results.map(createFormattedResult).filter(e => e !== undefined);
 
 }
 
@@ -159,7 +152,7 @@ fileUpload.addEventListener("change", () => {
 async function addElementMarkers(checkResult) {
   const bpmnViewer = await getBpmnViewer();
   var canvas = bpmnViewer.get('canvas');
-  checkResult[0].results.forEach(result => {
+  checkResult.results.forEach(result => {
     if (result.elementType !== 'process' && result.elementType !== 'message') {
       if (result.messages.length > 0) {
         const isWarning = result.messages.some(message => message.severity === 'WARNING');


### PR DESCRIPTION
## Description
For some time, the webapp was able to handle a multi-file upload. The current story does not align with this any more.

So, single file upload is back!

## Additional context
Closes #78 
Closes #142 
Closes #95 

## Testing your changes
The Integration tests for the REST API were adjusted to test the behaviour.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an existing open issue)
- [x] New feature (non-breaking change which adds functionality to an extension)
- [ ] Breaking change (fix or feature that would cause existing functionality of an extension to change)
- [ ] Documentation update (changes made to an existing piece of documentation)

## Checklist:
- [x] My code adheres to the syntax used by this extension.
- [x] My pull request requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **Camunda Community Hub** documentation.
- [x] I have read the **Pull Request Process** documentation.
- [x] I have added or suggested tests to cover my changes suggested in this pull request.
- [x] All new and existing CI/CD tests passed.
- [x] I will /assign myself this issue, and add the relevant [issue labels] to it if they are not automatically generated by Probot.
- [x] I will tag @camunda-community-hub/devrel in a new comment on this issue if 30 days have passed since my pull request was opened and I have not received a response from the extension's maintainer.
