### PR TITLE
[converter/core] bugfix: expression transformer now handles empty

### DIFF
--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/expression/ExpressionTransformer.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/expression/ExpressionTransformer.java
@@ -49,7 +49,7 @@ public class ExpressionTransformer {
     // replace operators globally
     String replaced =
         expression
-            .replaceAll("empty (\\S*)","$1=null")
+            .replaceAll("empty (\\S*)", "$1=null")
             // replace all !x with not(x)
             .replaceAll("!(?![\\(=])([\\S-^]*)", "not($1)")
             // replace all not x with not(x)

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/expression/ExpressionTransformer.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/expression/ExpressionTransformer.java
@@ -49,10 +49,11 @@ public class ExpressionTransformer {
     // replace operators globally
     String replaced =
         expression
+            .replaceAll("empty (\\S*)","$1=null")
             // replace all !x with not(x)
-            .replaceAll("!(?![\\(=])([\\w-^]*)", "not($1)")
+            .replaceAll("!(?![\\(=])([\\S-^]*)", "not($1)")
             // replace all not x with not(x)
-            .replaceAll("not (?![\\(=])([\\w-^]*)", "not($1)")
+            .replaceAll("not (?![\\(=])([\\S-^]*)", "not($1)")
             // replace all x["y"] with x.y
             .replaceAll("\\[\\\"(\\D[^\\]\\[]*)\\\"]", ".$1")
             .replaceAll(" gt ", " > ")

--- a/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/ExpressionTransformerTest.java
+++ b/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/ExpressionTransformerTest.java
@@ -1,15 +1,14 @@
 package org.camunda.community.migration.converter;
 
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.stream.Stream;
 import org.camunda.community.migration.converter.expression.ExpressionTransformationResult;
 import org.camunda.community.migration.converter.expression.ExpressionTransformer;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 public class ExpressionTransformerTest {
   private static final Logger LOG = LoggerFactory.getLogger(ExpressionTransformerTest.class);
@@ -56,11 +55,11 @@ public class ExpressionTransformerTest {
             test("#{customer.address[\"street\"]}", "=customer.address.street"),
             test("#{customer.orders[1]}", "=customer.orders[2]"),
             test("${not empty x}", "=not(x=null)"),
-            test("${empty donut}","=donut=null"),
-            test("${!empty donut}","=not(donut=null)"),
-            test("${empty donut || coffee}","=donut=null or coffee"),
-            test("${not empty donut || coffee}","=not(donut=null) or coffee"),
-            test("${not(empty donut || coffee)}","=not(donut=null or coffee)")),
+            test("${empty donut}", "=donut=null"),
+            test("${!empty donut}", "=not(donut=null)"),
+            test("${empty donut || coffee}", "=donut=null or coffee"),
+            test("${not empty donut || coffee}", "=not(donut=null) or coffee"),
+            test("${not(empty donut || coffee)}", "=not(donut=null or coffee)")),
         ExpressionTestDataSet::toString,
         this::testExpression);
   }

--- a/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/ExpressionTransformerTest.java
+++ b/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/ExpressionTransformerTest.java
@@ -1,14 +1,15 @@
 package org.camunda.community.migration.converter;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-import java.util.stream.Stream;
 import org.camunda.community.migration.converter.expression.ExpressionTransformationResult;
 import org.camunda.community.migration.converter.expression.ExpressionTransformer;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ExpressionTransformerTest {
   private static final Logger LOG = LoggerFactory.getLogger(ExpressionTransformerTest.class);
@@ -53,7 +54,13 @@ public class ExpressionTransformerTest {
             test("#{x or y}", "=x or y"),
             test("#{customer.name}", "=customer.name"),
             test("#{customer.address[\"street\"]}", "=customer.address.street"),
-            test("#{customer.orders[1]}", "=customer.orders[2]")),
+            test("#{customer.orders[1]}", "=customer.orders[2]"),
+            test("${not empty x}", "=not(x=null)"),
+            test("${empty donut}","=donut=null"),
+            test("${!empty donut}","=not(donut=null)"),
+            test("${empty donut || coffee}","=donut=null or coffee"),
+            test("${not empty donut || coffee}","=not(donut=null) or coffee"),
+            test("${not(empty donut || coffee)}","=not(donut=null or coffee)")),
         ExpressionTestDataSet::toString,
         this::testExpression);
   }


### PR DESCRIPTION
## Description
The empty keyword could not be handled correctly until now.

## Additional context
Closes #152 

## Testing your changes
There were added new test cases for the expression transformer.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an existing open issue)
- [ ] New feature (non-breaking change which adds functionality to an extension)
- [ ] Breaking change (fix or feature that would cause existing functionality of an extension to change)
- [ ] Documentation update (changes made to an existing piece of documentation)

## Checklist:
- [x] My code adheres to the syntax used by this extension.
- [ ] My pull request requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **Camunda Community Hub** documentation.
- [x] I have read the **Pull Request Process** documentation.
- [x] I have added or suggested tests to cover my changes suggested in this pull request.
- [x] All new and existing CI/CD tests passed.
- [x] I will /assign myself this issue, and add the relevant [issue labels] to it if they are not automatically generated by Probot.
- [x] I will tag @camunda-community-hub/devrel in a new comment on this issue if 30 days have passed since my pull request was opened and I have not received a response from the extension's maintainer.
