### PR TITLE
Change Business key message

### DIFF
--- a/backend-diagram-converter/core/src/main/resources/message-templates.properties
+++ b/backend-diagram-converter/core/src/main/resources/message-templates.properties
@@ -9,7 +9,7 @@ template.attribute-not-supported-prefix=Attribute '{{ attributeLocalName }}' wit
 template.element-not-supported-prefix=Element '{{ elementLocalName }}' is not supported in Zeebe version '{{ semanticVersion }}'.
 template.element-not-transformable-prefix=Element '{{ elementLocalName }}' cannot be transformed.
 template.element-transformed-prefix=Element '{{ elementLocalName }}' was transformed.
-template.business-key-not-supported=Business key is not supported in Zeebe.
+template.business-key-not-supported=businessKey has to be a process variable in Zeebe.
 template.execution-not-available='execution' is not available in FEEL.
 template.method-not-possible=Method invocation is not possible in FEEL.
 #


### PR DESCRIPTION
# Make the business key message more meaningful

In Camunda 8 the business key isn't a separated entity anymore. It should be treated as a normal process variable.

For migration from Camunda 7 it would be fine just to keep the name `businessKey`.

## Description

The new message is the first and simple step for this issue: #197 

More changes should follow. We can inspect the context better.

## Additional context

The current message `BusinessKey is not supported by Zeebe` is correct, but misleading.

## Testing your changes
<!--- Please describe in detail how you tested your changes. -->
<!--- Include any relevant details as to your testing environment, and any tests you ran to determine how/if your change impacts other areas of the extension's codebase, etc. -->

Manual tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an existing open issue)
- [ ] New feature (non-breaking change which adds functionality to an extension)
- [ ] Breaking change (fix or feature that would cause existing functionality of an extension to change)
- [ ] Documentation update (changes made to an existing piece of documentation)

## Checklist:
<!--- Please review the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code adheres to the syntax used by this extension.
- [ ] My pull request requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **Camunda Community Hub** documentation.
- [x] I have read the **Pull Request Process** documentation.
- [ ] I have added or suggested tests to cover my changes suggested in this pull request.
- [x] All new and existing CI/CD tests passed.
- [ ] I will /assign myself this issue, and add the relevant [issue labels] to it if they are not automatically generated by Probot.
- [ ] I will tag @camunda-community-hub/devrel in a new comment on this issue if 30 days have passed since my pull request was opened and I have not received a response from the extension's maintainer.
