### PR TITLE
[converter/core] bugfix: Empty expression was transformed to '='

### DIFF
--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/expression/ExpressionTransformer.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/expression/ExpressionTransformer.java
@@ -26,6 +26,9 @@ public class ExpressionTransformer {
     if (expression == null) {
       return null;
     }
+    if (expression.length() == 0) {
+      return "=null";
+    }
     // split into expressions and non-expressions
     List<String> nonExpressions =
         Arrays.stream(expression.split("(#|\\$)\\{.*}"))

--- a/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/BpmnConverterTest.java
+++ b/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/BpmnConverterTest.java
@@ -29,7 +29,8 @@ public class BpmnConverterTest {
         "example-c7_2.bpmn",
         "java-delegate-class-c7.bpmn",
         "old-process.bpmn20.xml",
-        "collaboration.bpmn"
+        "collaboration.bpmn",
+        "empty-input-parameter.bpmn"
       })
   public void shouldConvert(String bpmnFile) {
     BpmnConverter converter = BpmnConverterFactory.getInstance().get();
@@ -326,6 +327,17 @@ public class BpmnConverterTest {
             Arrays.asList("Completion condition", "Method invocation is not possible in FEEL"));
 
     assertThat(messages.get(3).getSeverity()).isEqualTo(Severity.INFO);
+  }
+
+  @Test
+  void testEmptyInputParameterMapping() {
+    BpmnDiagramCheckResult result = loadAndCheck("empty-input-parameter.bpmn");
+    List<BpmnElementCheckMessage> messages = result.getResult("AUserTaskTask").getMessages();
+    assertThat(messages).hasSize(1);
+    BpmnElementCheckMessage message = messages.get(0);
+    assertThat(message.getMessage())
+        .isEqualTo(
+            "Element 'inputParameter' was transformed. Parameter 'inputParameterName': Please review transformed expression: '' -> '=null'.");
   }
 
   protected BpmnDiagramCheckResult loadAndCheck(String bpmnFile) {

--- a/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/ExpressionTransformerTest.java
+++ b/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/ExpressionTransformerTest.java
@@ -20,6 +20,7 @@ public class ExpressionTransformerTest {
   @TestFactory
   public Stream<DynamicContainer> shouldResolveExpression() {
     return Stream.of(
+            expression("").isMappedTo("=null"),
             expression("${someVariable}").isMappedTo("=someVariable"),
             expression("someStaticValue").isMappedTo("someStaticValue"),
             expression("${var.innerField}").isMappedTo("=var.innerField"),
@@ -66,7 +67,7 @@ public class ExpressionTransformerTest {
         .map(
             data ->
                 DynamicContainer.dynamicContainer(
-                    data.getResult().getOldExpression(), data.getTests()));
+                    "Expression: " + data.getResult().getOldExpression(), data.getTests()));
   }
 
   private static class ExpressionTestBuilder {

--- a/backend-diagram-converter/core/src/test/resources/empty-input-parameter.bpmn
+++ b/backend-diagram-converter/core/src/test/resources/empty-input-parameter.bpmn
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0f0sc0g" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.8.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.18.0">
+  <bpmn:process id="EmptyInputParameterProcess" name="Empty Input Parameter" isExecutable="true">
+    <bpmn:startEvent id="StartStartEvent" name="Start">
+      <bpmn:outgoing>Flow_0dromh3</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0dromh3" sourceRef="StartStartEvent" targetRef="AUserTaskTask" />
+    <bpmn:endEvent id="EndEndEvent" name="End">
+      <bpmn:incoming>Flow_0zswavy</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0zswavy" sourceRef="AUserTaskTask" targetRef="EndEndEvent" />
+    <bpmn:userTask id="AUserTaskTask" name="A user task">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="inputParameterName" />
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0dromh3</bpmn:incoming>
+      <bpmn:outgoing>Flow_0zswavy</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="EmptyInputParameterProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartStartEvent">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="185" y="142" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0l0wp4s_di" bpmnElement="EndEndEvent">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="440" y="142" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0krxb6b_di" bpmnElement="AUserTaskTask">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0dromh3_di" bpmnElement="Flow_0dromh3">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0zswavy_di" bpmnElement="Flow_0zswavy">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Description
The expression transformer did interpret an empty string as expression and mapped it to an empty expression.
In fact, it makes more sense to map it to a null expression.

## Additional context
Closes #198 

## Testing your changes
There is a unit test for the expression itself as well as a converter test to assert the correct message.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an existing open issue)
- [ ] New feature (non-breaking change which adds functionality to an extension)
- [ ] Breaking change (fix or feature that would cause existing functionality of an extension to change)
- [ ] Documentation update (changes made to an existing piece of documentation)

## Checklist:
- [x] My code adheres to the syntax used by this extension.
- [x] My pull request requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **Camunda Community Hub** documentation.
- [x] I have read the **Pull Request Process** documentation.
- [x] I have added or suggested tests to cover my changes suggested in this pull request.
- [x] All new and existing CI/CD tests passed.
- [x] I will /assign myself this issue, and add the relevant [issue labels] to it if they are not automatically generated by Probot.
- [x] I will tag @camunda-community-hub/devrel in a new comment on this issue if 30 days have passed since my pull request was opened and I have not received a response from the extension's maintainer.
