### PR TITLE
[general] task: Remove not required pom.xml entries

### DIFF
--- a/backend-diagram-converter/cli/pom.xml
+++ b/backend-diagram-converter/cli/pom.xml
@@ -95,7 +95,6 @@
           <archive>
             <manifest>
               <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-              <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
             </manifest>
           </archive>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-extension-testcontainer</artifactId>
-        <version>${version.zeebe}</version>
+        <version>${version.version.zeebe-process-test-extension-testcontainer}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-extension-testcontainer</artifactId>
-        <version>${version.version.zeebe-process-test-extension-testcontainer}</version>
+        <version>${version.zeebe-process-test-extension-testcontainer}</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
## Description
With the release of the parent in version 1.4.2, there was the hope that we could now remove our added pom.xml configs to append build information to the manifest files.

This is not the case, however we can remove one thing.

## Additional context
Follow up to #221 

## Testing your changes
There is a unit test in place that starts an app which relies on a manifest entry.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an existing open issue)
- [ ] New feature (non-breaking change which adds functionality to an extension)
- [ ] Breaking change (fix or feature that would cause existing functionality of an extension to change)
- [ ] Documentation update (changes made to an existing piece of documentation)

## Checklist:
- [x] My code adheres to the syntax used by this extension.
- [x] My pull request requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **Camunda Community Hub** documentation.
- [x] I have read the **Pull Request Process** documentation.
- [x] I have added or suggested tests to cover my changes suggested in this pull request.
- [x] All new and existing CI/CD tests passed.
- [x] I will /assign myself this issue, and add the relevant [issue labels] to it if they are not automatically generated by Probot.
- [x] I will tag @camunda-community-hub/devrel in a new comment on this issue if 30 days have passed since my pull request was opened and I have not received a response from the extension's maintainer.
