### PR TITLE
fixed a bug where an errorCode is not transformed

### DIFF
--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/eventReference/ErrorVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/eventReference/ErrorVisitor.java
@@ -35,6 +35,9 @@ public class ErrorVisitor extends AbstractEventReferenceVisitor {
     if (expressionTransformationResult.getNewExpression().startsWith("=")) {
       context.addMessage(MessageFactory.errorCodeNoExpression());
     }
+    context.addConversion(
+        ErrorConvertible.class,
+        c -> c.setErrorCode(expressionTransformationResult.getNewExpression()));
     // this can be enabled as soon as error codes can be expressions
     /*
     if (SemanticVersion.parse(context.getProperties().getPlatformVersion()).ordinal()

--- a/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/BpmnConverterTest.java
+++ b/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/BpmnConverterTest.java
@@ -392,4 +392,16 @@ public class BpmnConverterTest {
         .isEqualTo(
             "Listener at 'start' with implementation 'null' cannot be transformed. Execution Listeners do not exist in Zeebe.");
   }
+
+  @Test
+  void testErrorCodeShouldPersist() {
+    BpmnModelInstance modelInstance = loadAndConvert("error-code.bpmn");
+    assertThat(
+            modelInstance.getDocument().getElementById("Error_16zktjx").getAttribute("errorCode"))
+        .isEqualTo("someCode");
+    BpmnConverter converter = BpmnConverterFactory.getInstance().get();
+    StringWriter writer = new StringWriter();
+    converter.printXml(modelInstance.getDocument(), true, writer);
+    System.out.println(writer.toString());
+  }
 }

--- a/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/TestUtil.java
+++ b/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/TestUtil.java
@@ -15,6 +15,14 @@ public class TestUtil {
     return variables;
   }
 
+  public static BpmnModelInstance loadAndConvert(String bpmnFile) {
+    BpmnModelInstance modelInstance = loadModelInstance(bpmnFile);
+    BpmnConverter converter = BpmnConverterFactory.getInstance().get();
+    ConverterProperties properties = ConverterPropertiesFactory.getInstance().get();
+    converter.convert(modelInstance, false, properties);
+    return modelInstance;
+  }
+
   public static BpmnDiagramCheckResult loadAndCheck(String bpmnFile) {
     ConverterProperties properties = ConverterPropertiesFactory.getInstance().get();
     return loadAndCheckAgainstVersion(bpmnFile, properties.getPlatformVersion());
@@ -23,8 +31,7 @@ public class TestUtil {
   public static BpmnDiagramCheckResult loadAndCheckAgainstVersion(
       String bpmnFile, String targetVersion) {
     BpmnConverter converter = BpmnConverterFactory.getInstance().get();
-    BpmnModelInstance modelInstance =
-        Bpmn.readModelFromStream(TestUtil.class.getClassLoader().getResourceAsStream(bpmnFile));
+    BpmnModelInstance modelInstance = loadModelInstance(bpmnFile);
     DefaultConverterProperties properties = new DefaultConverterProperties();
     properties.setPlatformVersion(targetVersion);
     BpmnDiagramCheckResult result =
@@ -34,5 +41,9 @@ public class TestUtil {
             false,
             ConverterPropertiesFactory.getInstance().merge(properties));
     return result;
+  }
+
+  private static BpmnModelInstance loadModelInstance(String bpmnFile) {
+    return Bpmn.readModelFromStream(TestUtil.class.getClassLoader().getResourceAsStream(bpmnFile));
   }
 }

--- a/backend-diagram-converter/core/src/test/resources/error-code.bpmn
+++ b/backend-diagram-converter/core/src/test/resources/error-code.bpmn
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1gbx4qr" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.19.0">
+  <bpmn:process id="TransactionTestProcess" name="Transaction Test" isExecutable="true" />
+  <bpmn:error id="Error_16zktjx" name="SomeName" errorCode="someCode" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="TransactionTestProcess" />
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Description
Since 0.6, this was broken. Now it works (and is tested)

## Additional context
.

## Testing your changes
One new unit test asserts the presence of an error code after the conversion

## Types of changes
- [x] Bug fix (non-breaking change which fixes an existing open issue)
- [ ] New feature (non-breaking change which adds functionality to an extension)
- [ ] Breaking change (fix or feature that would cause existing functionality of an extension to change)
- [ ] Documentation update (changes made to an existing piece of documentation)

## Checklist:
- [x] My code adheres to the syntax used by this extension.
- [x] My pull request requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **Camunda Community Hub** documentation.
- [x] I have read the **Pull Request Process** documentation.
- [x] I have added or suggested tests to cover my changes suggested in this pull request.
- [x] All new and existing CI/CD tests passed.
- [x] I will /assign myself this issue, and add the relevant [issue labels] to it if they are not automatically generated by Probot.
- [x] I will tag @camunda-community-hub/devrel in a new comment on this issue if 30 days have passed since my pull request was opened and I have not received a response from the extension's maintainer.
