### PR TITLE
[feature][converter/cli]: `defaultJobTypeEnabled` as flag

### DIFF
--- a/backend-diagram-converter/cli/README.md
+++ b/backend-diagram-converter/cli/README.md
@@ -24,8 +24,8 @@ java -Dfile.encoding=UTF-8 -jar backend-diagram-converter-cli-version.jar
 ### Convert diagrams from the local file systems
 
 ```
-Usage: backend-diagram-converter-cli local [-dhoV] [--check] [--csv] [-nr]
-       [--adapter-job-type=<adapterJobType>]
+Usage: backend-diagram-converter-cli local [-dhoV] [--check] [--csv]
+       [--disable-adapter] [-nr] [--adapter-job-type=<adapterJobType>]
        [--platform-version=<platformVersion>] [--prefix=<prefix>] <file>
 Converts the diagram from the given directory or file
 
@@ -44,6 +44,8 @@ Options:
                                the results for all conversions
   -d, --documentation        If enabled, messages are also appended to
                                documentation
+      --disable-adapter      If enabled, the adapter job type will not be
+                               applied
   -h, --help                 Show this help message and exit.
       -nr, --not-recursive   If enabled, recursive search in subfolders will be
                                omitted
@@ -66,9 +68,9 @@ java -Dfile.encoding=UTF-8 -jar backend-diagram-converter-cli-v.v.v.jar local c:
 
 ```
 Usage: backend-diagram-converter-cli engine [-dhoV] [--check] [--csv]
-       [--adapter-job-type=<adapterJobType>] [-p=<password>]
-       [--platform-version=<platformVersion>] [--prefix=<prefix>]
-       [-t=<targetDirectory>] [-u=<username>] <url>
+       [--disable-adapter] [--adapter-job-type=<adapterJobType>]
+       [-p=<password>] [--platform-version=<platformVersion>]
+       [--prefix=<prefix>] [-t=<targetDirectory>] [-u=<username>] <url>
 Description: Converts the diagrams from the given process engine
 
 Execute as:
@@ -88,6 +90,7 @@ Options:
                             results for all conversions
   -d, --documentation     If enabled, messages are also appended to
                             documentation
+      --disable-adapter   If enabled, the adapter job type will not be applied
   -h, --help              Show this help message and exit.
   -o, --override          If enabled, existing files are overridden
   -p, --password=<password>
@@ -122,7 +125,7 @@ Enter the folder with the latest version and download
 You can start the jar file from the command line with
 
 ```shell
-java -jar backend-diagram-converter-cli-0.4.3.jar --help
+java -jar backend-diagram-converter-cli-v.v.v.jar --help
 ```
 
 ## Compile from source

--- a/backend-diagram-converter/cli/README.md
+++ b/backend-diagram-converter/cli/README.md
@@ -25,7 +25,7 @@ java -Dfile.encoding=UTF-8 -jar backend-diagram-converter-cli-version.jar
 
 ```
 Usage: backend-diagram-converter-cli local [-dhoV] [--check] [--csv]
-       [--disable-adapter] [-nr] [--adapter-job-type=<adapterJobType>]
+       [--disable-default-job-type] [-nr] [--default-job-type=<defaultJobType>]
        [--platform-version=<platformVersion>] [--prefix=<prefix>] <file>
 Converts the diagram from the given directory or file
 
@@ -36,16 +36,17 @@ java -Dfile.encoding=UTF-8 -jar backend-diagram-converter-cli.jar local
 Parameter:
       <file>                 The file to convert or directory to search in
 Options:
-      --adapter-job-type=<adapterJobType>
-                             If set, the default value for the adapter job is
-                               overridden
       --check                If enabled, no converted diagrams are exported
       --csv                  If enabled, a CSV file will be created containing
                                the results for all conversions
   -d, --documentation        If enabled, messages are also appended to
                                documentation
-      --disable-adapter      If enabled, the adapter job type will not be
-                               applied
+      --default-job-type=<defaultJobType>
+                             If set, the default value from the
+                               'converter-properties.properties' for the job
+                               type is overridden
+      --disable-default-job-type
+                             Disables the default job type
   -h, --help                 Show this help message and exit.
       -nr, --not-recursive   If enabled, recursive search in subfolders will be
                                omitted
@@ -68,7 +69,7 @@ java -Dfile.encoding=UTF-8 -jar backend-diagram-converter-cli-v.v.v.jar local c:
 
 ```
 Usage: backend-diagram-converter-cli engine [-dhoV] [--check] [--csv]
-       [--disable-adapter] [--adapter-job-type=<adapterJobType>]
+       [--disable-default-job-type] [--default-job-type=<defaultJobType>]
        [-p=<password>] [--platform-version=<platformVersion>]
        [--prefix=<prefix>] [-t=<targetDirectory>] [-u=<username>] <url>
 Description: Converts the diagrams from the given process engine
@@ -82,15 +83,17 @@ Parameter:
                             REST API
                             Default: http://localhost:8080/engine-rest
 Options:
-      --adapter-job-type=<adapterJobType>
-                          If set, the default value for the adapter job is
-                            overridden
       --check             If enabled, no converted diagrams are exported
       --csv               If enabled, a CSV file will be created containing the
                             results for all conversions
   -d, --documentation     If enabled, messages are also appended to
                             documentation
-      --disable-adapter   If enabled, the adapter job type will not be applied
+      --default-job-type=<defaultJobType>
+                          If set, the default value from the
+                            'converter-properties.properties' for the job type
+                            is overridden
+      --disable-default-job-type
+                          Disables the default job type
   -h, --help              Show this help message and exit.
   -o, --override          If enabled, existing files are overridden
   -p, --password=<password>

--- a/backend-diagram-converter/cli/src/main/java/org/camunda/community/migration/converter/cli/AbstractConvertCommand.java
+++ b/backend-diagram-converter/cli/src/main/java/org/camunda/community/migration/converter/cli/AbstractConvertCommand.java
@@ -61,6 +61,11 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
   @Option(names = "--check", description = "If enabled, no converted diagrams are exported")
   boolean check;
 
+  @Option(
+      names = "--disable-adapter",
+      description = "If enabled, the adapter job type will not be applied")
+  boolean adapterDisabled;
+
   public AbstractConvertCommand() {
     BpmnConverterFactory factory = BpmnConverterFactory.getInstance();
     factory.getNotificationServiceFactory().setInstance(new PrintNotificationServiceImpl());
@@ -136,6 +141,7 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
     DefaultConverterProperties properties = new DefaultConverterProperties();
     properties.setAdapterJobType(adapterJobType);
     properties.setPlatformVersion(platformVersion);
+    properties.setAdapterEnabled(!adapterDisabled);
     return properties;
   }
 

--- a/backend-diagram-converter/cli/src/main/java/org/camunda/community/migration/converter/cli/AbstractConvertCommand.java
+++ b/backend-diagram-converter/cli/src/main/java/org/camunda/community/migration/converter/cli/AbstractConvertCommand.java
@@ -32,9 +32,9 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
   boolean documentation;
 
   @Option(
-      names = {"--adapter-job-type"},
+      names = {"--default-job-type"},
       description = "If set, the default value for the adapter job is overridden")
-  String adapterJobType;
+  String defaultJobType;
 
   @Option(
       names = {"--prefix"},
@@ -62,9 +62,9 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
   boolean check;
 
   @Option(
-      names = "--disable-adapter",
-      description = "If enabled, the adapter job type will not be applied")
-  boolean adapterDisabled;
+      names = "--disable-default-job-type",
+      description = "If enabled, the default job type will not be applied")
+  boolean defaultJobTypeDisabled;
 
   public AbstractConvertCommand() {
     BpmnConverterFactory factory = BpmnConverterFactory.getInstance();
@@ -138,9 +138,9 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
 
   protected DefaultConverterProperties converterProperties() {
     DefaultConverterProperties properties = new DefaultConverterProperties();
-    properties.setAdapterJobType(adapterJobType);
+    properties.setDefaultJobType(defaultJobType);
     properties.setPlatformVersion(platformVersion);
-    properties.setAdapterEnabled(!adapterDisabled);
+    properties.setDefaultJobTypeEnabled(!defaultJobTypeDisabled);
     properties.setAppendDocumentation(documentation);
     return properties;
   }

--- a/backend-diagram-converter/cli/src/main/java/org/camunda/community/migration/converter/cli/AbstractConvertCommand.java
+++ b/backend-diagram-converter/cli/src/main/java/org/camunda/community/migration/converter/cli/AbstractConvertCommand.java
@@ -126,7 +126,6 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
       return converter.check(
           modelInstance.getKey().getAbsolutePath(),
           modelInstance.getValue(),
-          documentation,
           ConverterPropertiesFactory.getInstance().merge(converterProperties()));
     } catch (Exception e) {
       LOG_CLI.error("Problem while converting: {}", createMessage(e));
@@ -142,6 +141,7 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
     properties.setAdapterJobType(adapterJobType);
     properties.setPlatformVersion(platformVersion);
     properties.setAdapterEnabled(!adapterDisabled);
+    properties.setAppendDocumentation(documentation);
     return properties;
   }
 

--- a/backend-diagram-converter/cli/src/main/java/org/camunda/community/migration/converter/cli/AbstractConvertCommand.java
+++ b/backend-diagram-converter/cli/src/main/java/org/camunda/community/migration/converter/cli/AbstractConvertCommand.java
@@ -33,7 +33,8 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
 
   @Option(
       names = {"--default-job-type"},
-      description = "If set, the default value for the adapter job is overridden")
+      description =
+          "If set, the default value from the 'converter-properties.properties' for the job type is overridden")
   String defaultJobType;
 
   @Option(
@@ -61,9 +62,7 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
   @Option(names = "--check", description = "If enabled, no converted diagrams are exported")
   boolean check;
 
-  @Option(
-      names = "--disable-default-job-type",
-      description = "If enabled, the default job type will not be applied")
+  @Option(names = "--disable-default-job-type", description = "Disables the default job type")
   boolean defaultJobTypeDisabled;
 
   public AbstractConvertCommand() {

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/BpmnConverter.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/BpmnConverter.java
@@ -47,18 +47,12 @@ public class BpmnConverter {
     this.notificationService = notificationService;
   }
 
-  public void convert(
-      BpmnModelInstance modelInstance,
-      boolean appendDocumentation,
-      ConverterProperties properties) {
-    check(null, modelInstance, appendDocumentation, properties);
+  public void convert(BpmnModelInstance modelInstance, ConverterProperties properties) {
+    check(null, modelInstance, properties);
   }
 
   public BpmnDiagramCheckResult check(
-      String filename,
-      BpmnModelInstance modelInstance,
-      boolean appendDocumentation,
-      ConverterProperties properties) {
+      String filename, BpmnModelInstance modelInstance, ConverterProperties properties) {
     LOG.info("Start check");
     BpmnDiagramCheckResult result = new BpmnDiagramCheckResult();
     result.setFilename(filename);
@@ -90,7 +84,7 @@ public class BpmnConverter {
               conversionElementAppender.appendMessages(element, messages);
               conversionElementAppender.appendReferences(element, references);
               conversionElementAppender.appendReferencedBy(element, referencedBys);
-              if (appendDocumentation) {
+              if (properties.getAppendDocumentation()) {
                 conversionElementAppender.appendDocumentation(
                     element, collectMessages(result, messages, references));
               }

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/ConverterProperties.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/ConverterProperties.java
@@ -6,7 +6,7 @@ public interface ConverterProperties {
 
   String getResultVariableHeader();
 
-  String getAdapterJobType();
+  String getDefaultJobType();
 
   String getScriptJobType();
 
@@ -16,7 +16,7 @@ public interface ConverterProperties {
 
   String getPlatformVersion();
 
-  Boolean getAdapterEnabled();
+  Boolean getDefaultJobTypeEnabled();
 
   Boolean getAppendDocumentation();
 }

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/ConverterProperties.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/ConverterProperties.java
@@ -15,4 +15,6 @@ public interface ConverterProperties {
   String getScriptFormatHeader();
 
   String getPlatformVersion();
+
+  Boolean getAdapterEnabled();
 }

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/ConverterProperties.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/ConverterProperties.java
@@ -17,4 +17,6 @@ public interface ConverterProperties {
   String getPlatformVersion();
 
   Boolean getAdapterEnabled();
+
+  Boolean getAppendDocumentation();
 }

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/ConverterPropertiesFactory.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/ConverterPropertiesFactory.java
@@ -41,7 +41,7 @@ public class ConverterPropertiesFactory extends AbstractFactory<ConverterPropert
   }
 
   private void readDefaultValues(DefaultConverterProperties properties) {
-    readZeebeJobType("adapter", properties::getAdapterJobType, properties::setAdapterJobType);
+    readZeebeJobType("default", properties::getDefaultJobType, properties::setDefaultJobType);
     readZeebeJobType("script", properties::getScriptJobType, properties::setScriptJobType);
     readZeebeHeader("script", properties::getScriptHeader, properties::setScriptHeader);
     readZeebeHeader(
@@ -53,7 +53,10 @@ public class ConverterPropertiesFactory extends AbstractFactory<ConverterPropert
         "script-format", properties::getScriptFormatHeader, properties::setScriptFormatHeader);
     readZeebePlatformInfo(
         "version", properties::getPlatformVersion, properties::setPlatformVersion);
-    readFlag("adapter-enabled", properties::getAdapterEnabled, properties::setAdapterEnabled);
+    readFlag(
+        "default-job-type-enabled",
+        properties::getDefaultJobTypeEnabled,
+        properties::setDefaultJobTypeEnabled);
     readFlag(
         "append-documentation",
         properties::getAppendDocumentation,

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/ConverterPropertiesFactory.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/ConverterPropertiesFactory.java
@@ -54,6 +54,10 @@ public class ConverterPropertiesFactory extends AbstractFactory<ConverterPropert
     readZeebePlatformInfo(
         "version", properties::getPlatformVersion, properties::setPlatformVersion);
     readFlag("adapter-enabled", properties::getAdapterEnabled, properties::setAdapterEnabled);
+    readFlag(
+        "append-documentation",
+        properties::getAppendDocumentation,
+        properties::setAppendDocumentation);
   }
 
   private void readZeebeJobType(String jobType, Supplier<String> getter, Consumer<String> setter) {

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/DefaultConverterProperties.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/DefaultConverterProperties.java
@@ -3,12 +3,12 @@ package org.camunda.community.migration.converter;
 public class DefaultConverterProperties implements ConverterProperties {
   private String scriptHeader;
   private String resultVariableHeader;
-  private String adapterJobType;
+  private String defaultJobType;
   private String scriptJobType;
   private String resourceHeader;
   private String scriptFormatHeader;
   private String platformVersion;
-  private Boolean adapterEnabled;
+  private Boolean defaultJobTypeEnabled;
   private Boolean appendDocumentation;
 
   @Override
@@ -21,12 +21,12 @@ public class DefaultConverterProperties implements ConverterProperties {
   }
 
   @Override
-  public Boolean getAdapterEnabled() {
-    return adapterEnabled;
+  public Boolean getDefaultJobTypeEnabled() {
+    return defaultJobTypeEnabled;
   }
 
-  public void setAdapterEnabled(Boolean adapterEnabled) {
-    this.adapterEnabled = adapterEnabled;
+  public void setDefaultJobTypeEnabled(Boolean defaultJobTypeEnabled) {
+    this.defaultJobTypeEnabled = defaultJobTypeEnabled;
   }
 
   @Override
@@ -57,12 +57,12 @@ public class DefaultConverterProperties implements ConverterProperties {
   }
 
   @Override
-  public String getAdapterJobType() {
-    return adapterJobType;
+  public String getDefaultJobType() {
+    return defaultJobType;
   }
 
-  public void setAdapterJobType(String adapterJobType) {
-    this.adapterJobType = adapterJobType;
+  public void setDefaultJobType(String defaultJobType) {
+    this.defaultJobType = defaultJobType;
   }
 
   @Override

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/DefaultConverterProperties.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/DefaultConverterProperties.java
@@ -9,13 +9,23 @@ public class DefaultConverterProperties implements ConverterProperties {
   private String scriptFormatHeader;
   private String platformVersion;
   private Boolean adapterEnabled;
+  private Boolean appendDocumentation;
+
+  @Override
+  public Boolean getAppendDocumentation() {
+    return appendDocumentation;
+  }
+
+  public void setAppendDocumentation(Boolean appendDocumentation) {
+    this.appendDocumentation = appendDocumentation;
+  }
 
   @Override
   public Boolean getAdapterEnabled() {
     return adapterEnabled;
   }
 
-  public void setAdapterEnabled(boolean adapterEnabled) {
+  public void setAdapterEnabled(Boolean adapterEnabled) {
     this.adapterEnabled = adapterEnabled;
   }
 

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/DefaultConverterProperties.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/DefaultConverterProperties.java
@@ -8,6 +8,16 @@ public class DefaultConverterProperties implements ConverterProperties {
   private String resourceHeader;
   private String scriptFormatHeader;
   private String platformVersion;
+  private Boolean adapterEnabled;
+
+  @Override
+  public Boolean getAdapterEnabled() {
+    return adapterEnabled;
+  }
+
+  public void setAdapterEnabled(boolean adapterEnabled) {
+    this.adapterEnabled = adapterEnabled;
+  }
 
   @Override
   public String getPlatformVersion() {

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/message/MessageFactory.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/message/MessageFactory.java
@@ -470,9 +470,10 @@ public class MessageFactory {
             .build());
   }
 
-  public static Message delegateImplementationNoAdapter(String implementationType, String binding) {
+  public static Message delegateImplementationNoDefaultJobType(
+      String implementationType, String binding) {
     return INSTANCE.composeMessage(
-        "delegate-implementation-no-adapter",
+        "delegate-implementation-no-default-job-type",
         ContextBuilder.builder()
             .entry("implementationType", implementationType)
             .entry("binding", binding)

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/message/MessageFactory.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/message/MessageFactory.java
@@ -470,6 +470,15 @@ public class MessageFactory {
             .build());
   }
 
+  public static Message delegateImplementationNoAdapter(String implementationType, String binding) {
+    return INSTANCE.composeMessage(
+        "delegate-implementation-no-adapter",
+        ContextBuilder.builder()
+            .entry("implementationType", implementationType)
+            .entry("binding", binding)
+            .build());
+  }
+
   public static Message fieldContent(String elementLocalName) {
     return INSTANCE.composeMessage(
         "field-content",

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/AbstractDelegateImplementationVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/AbstractDelegateImplementationVisitor.java
@@ -16,21 +16,25 @@ public abstract class AbstractDelegateImplementationVisitor
 
   @Override
   protected Message visitSupportedAttribute(DomElementVisitorContext context, String attribute) {
-    context.addConversion(
-        ServiceTaskConvertible.class,
-        serviceTaskConversion ->
-            serviceTaskConversion.addZeebeTaskHeader(attributeLocalName(), attribute));
-    context.addConversion(
-        ServiceTaskConvertible.class,
-        serviceTaskConversion ->
-            serviceTaskConversion
-                .getZeebeTaskDefinition()
-                .setType(context.getProperties().getAdapterJobType()));
-    return MessageFactory.delegateImplementation(
-        attributeLocalName(),
-        context.getElement().getLocalName(),
-        attribute,
-        context.getProperties().getAdapterJobType());
+    if (context.getProperties().getAdapterEnabled()) {
+      context.addConversion(
+          ServiceTaskConvertible.class,
+          serviceTaskConversion ->
+              serviceTaskConversion.addZeebeTaskHeader(attributeLocalName(), attribute));
+      context.addConversion(
+          ServiceTaskConvertible.class,
+          serviceTaskConversion ->
+              serviceTaskConversion
+                  .getZeebeTaskDefinition()
+                  .setType(context.getProperties().getAdapterJobType()));
+      return MessageFactory.delegateImplementation(
+          attributeLocalName(),
+          context.getElement().getLocalName(),
+          attribute,
+          context.getProperties().getAdapterJobType());
+    } else {
+      return MessageFactory.delegateImplementationNoAdapter(attributeLocalName(), attribute);
+    }
   }
 
   @Override

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/AbstractDelegateImplementationVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/AbstractDelegateImplementationVisitor.java
@@ -16,7 +16,7 @@ public abstract class AbstractDelegateImplementationVisitor
 
   @Override
   protected Message visitSupportedAttribute(DomElementVisitorContext context, String attribute) {
-    if (context.getProperties().getAdapterEnabled()) {
+    if (context.getProperties().getDefaultJobTypeEnabled()) {
       context.addConversion(
           ServiceTaskConvertible.class,
           serviceTaskConversion ->
@@ -26,14 +26,14 @@ public abstract class AbstractDelegateImplementationVisitor
           serviceTaskConversion ->
               serviceTaskConversion
                   .getZeebeTaskDefinition()
-                  .setType(context.getProperties().getAdapterJobType()));
+                  .setType(context.getProperties().getDefaultJobType()));
       return MessageFactory.delegateImplementation(
           attributeLocalName(),
           context.getElement().getLocalName(),
           attribute,
-          context.getProperties().getAdapterJobType());
+          context.getProperties().getDefaultJobType());
     } else {
-      return MessageFactory.delegateImplementationNoAdapter(attributeLocalName(), attribute);
+      return MessageFactory.delegateImplementationNoDefaultJobType(attributeLocalName(), attribute);
     }
   }
 

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/AbstractSupportedAttributeVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/AbstractSupportedAttributeVisitor.java
@@ -8,7 +8,9 @@ public abstract class AbstractSupportedAttributeVisitor extends AbstractCamundaA
   @Override
   protected void visitAttribute(DomElementVisitorContext context, String attribute) {
     Message message = visitSupportedAttribute(context, attribute);
-    context.addMessage(message);
+    if (message != null) {
+      context.addMessage(message);
+    }
   }
 
   protected abstract Message visitSupportedAttribute(

--- a/backend-diagram-converter/core/src/main/resources/converter-properties.properties
+++ b/backend-diagram-converter/core/src/main/resources/converter-properties.properties
@@ -17,3 +17,5 @@ zeebe-platform.version=8.2.0
 # Flags
 ## Enable Adapter usage
 flag.adapter-enabled=true
+## Append documentation
+flag.append-documentation=false

--- a/backend-diagram-converter/core/src/main/resources/converter-properties.properties
+++ b/backend-diagram-converter/core/src/main/resources/converter-properties.properties
@@ -1,6 +1,6 @@
 # Zeebe Job Types
 ## Adapter
-zeebe-job-type.adapter=camunda-7-adapter
+zeebe-job-type.default=camunda-7-adapter
 ## Script
 zeebe-job-type.script=script
 # Zeebe Headers
@@ -15,7 +15,7 @@ zeebe-header.script-format=scriptFormat
 # Zeebe Meta Information
 zeebe-platform.version=8.2.0
 # Flags
-## Enable Adapter usage
-flag.adapter-enabled=true
+## Enable Default Job Type usage
+flag.default-job-type-enabled=true
 ## Append documentation
 flag.append-documentation=false

--- a/backend-diagram-converter/core/src/main/resources/converter-properties.properties
+++ b/backend-diagram-converter/core/src/main/resources/converter-properties.properties
@@ -14,3 +14,6 @@ zeebe-header.resource=resource
 zeebe-header.script-format=scriptFormat
 # Zeebe Meta Information
 zeebe-platform.version=8.2.0
+# Flags
+## Enable Adapter usage
+flag.adapter-enabled=true

--- a/backend-diagram-converter/core/src/main/resources/message-templates.properties
+++ b/backend-diagram-converter/core/src/main/resources/message-templates.properties
@@ -124,6 +124,9 @@ form-key.severity=REVIEW
 delegate-implementation.message={{ templates.supported-attribute-prefix }} Delegate call to '{{ binding }}' was transformed to job type '{{ jobType }}'. Please review your implementation.
 delegate-implementation.severity=REVIEW
 #
+delegate-implementation-no-adapter.message=Delegate call of type '{{ implementationType }}' bound to '{{ binding }}' was reset.
+delegate-implementation-no-adapter.severity=TASK
+#
 script-job-type.message=Element '{{ elementLocalName }}' was transformed. Currently, script tasks are implemented like service tasks with job type '{{ jobType }}'. Please review your implementation.
 script-job-type.severity=REVIEW
 #

--- a/backend-diagram-converter/core/src/main/resources/message-templates.properties
+++ b/backend-diagram-converter/core/src/main/resources/message-templates.properties
@@ -124,8 +124,8 @@ form-key.severity=REVIEW
 delegate-implementation.message={{ templates.supported-attribute-prefix }} Delegate call to '{{ binding }}' was transformed to job type '{{ jobType }}'. Please review your implementation.
 delegate-implementation.severity=REVIEW
 #
-delegate-implementation-no-adapter.message=Delegate call of type '{{ implementationType }}' bound to '{{ binding }}' was reset.
-delegate-implementation-no-adapter.severity=INFO
+delegate-implementation-no-default-job-type.message=Delegate call of type '{{ implementationType }}' bound to '{{ binding }}' was reset.
+delegate-implementation-no-default-job-type.severity=INFO
 #
 script-job-type.message=Element '{{ elementLocalName }}' was transformed. Currently, script tasks are implemented like service tasks with job type '{{ jobType }}'. Please review your implementation.
 script-job-type.severity=REVIEW

--- a/backend-diagram-converter/core/src/main/resources/message-templates.properties
+++ b/backend-diagram-converter/core/src/main/resources/message-templates.properties
@@ -125,7 +125,7 @@ delegate-implementation.message={{ templates.supported-attribute-prefix }} Deleg
 delegate-implementation.severity=REVIEW
 #
 delegate-implementation-no-adapter.message=Delegate call of type '{{ implementationType }}' bound to '{{ binding }}' was reset.
-delegate-implementation-no-adapter.severity=TASK
+delegate-implementation-no-adapter.severity=INFO
 #
 script-job-type.message=Element '{{ elementLocalName }}' was transformed. Currently, script tasks are implemented like service tasks with job type '{{ jobType }}'. Please review your implementation.
 script-job-type.severity=REVIEW

--- a/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/BehaviourTest.java
+++ b/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/BehaviourTest.java
@@ -28,7 +28,7 @@ public class BehaviourTest {
     BpmnConverter converter = BpmnConverterFactory.getInstance().get();
     ConverterProperties properties = ConverterPropertiesFactory.getInstance().get();
     BpmnModelInstance modelInstance = BpmnModelInstanceUtil.fromResource(CALL_ACTIVITY_BEHAVIOUR);
-    converter.convert(modelInstance, false, properties);
+    converter.convert(modelInstance, properties);
     client
         .newDeployResourceCommand()
         .addProcessModel(BpmnModelInstanceUtil.transform(modelInstance), "test.bpmn")

--- a/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/BpmnConverterTest.java
+++ b/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/BpmnConverterTest.java
@@ -475,7 +475,7 @@ public class BpmnConverterTest {
   @Test
   void testAdapterDisabled() {
     DefaultConverterProperties modified = new DefaultConverterProperties();
-    modified.setAdapterEnabled(false);
+    modified.setDefaultJobTypeEnabled(false);
     ConverterProperties properties = ConverterPropertiesFactory.getInstance().merge(modified);
     BpmnConverter converter = BpmnConverterFactory.getInstance().get();
     BpmnModelInstance modelInstance =

--- a/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/BpmnConverterTest.java
+++ b/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/BpmnConverterTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.camunda.bpm.model.bpmn.Bpmn;
 import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.camunda.bpm.model.xml.instance.DomElement;
 import org.camunda.community.migration.converter.BpmnDiagramCheckResult.BpmnElementCheckMessage;
 import org.camunda.community.migration.converter.BpmnDiagramCheckResult.BpmnElementCheckResult;
 import org.camunda.community.migration.converter.BpmnDiagramCheckResult.Severity;
@@ -469,5 +470,24 @@ public class BpmnConverterTest {
     } else {
       assertThat(warningMessages).hasSize(1);
     }
+  }
+
+  @Test
+  void testAdapterDisabled() {
+    DefaultConverterProperties modified = new DefaultConverterProperties();
+    modified.setAdapterEnabled(false);
+    ConverterProperties properties = ConverterPropertiesFactory.getInstance().merge(modified);
+    BpmnConverter converter = BpmnConverterFactory.getInstance().get();
+    BpmnModelInstance modelInstance =
+        Bpmn.readModelFromStream(getClass().getClassLoader().getResourceAsStream("delegate.bpmn"));
+    converter.convert(modelInstance, false, properties);
+    List<DomElement> taskDefinition =
+        modelInstance
+            .getDocument()
+            .getElementById("serviceTask")
+            .getChildElementsByNameNs(BPMN, "extensionElements")
+            .get(0)
+            .getChildElementsByNameNs(ZEEBE, "taskDefinition");
+    assertThat(taskDefinition).isEmpty();
   }
 }

--- a/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/BpmnConverterTest.java
+++ b/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/BpmnConverterTest.java
@@ -45,7 +45,7 @@ public class BpmnConverterTest {
     BpmnModelInstance modelInstance =
         Bpmn.readModelFromStream(this.getClass().getClassLoader().getResourceAsStream(bpmnFile));
     printModel(modelInstance);
-    BpmnDiagramCheckResult result = converter.check(bpmnFile, modelInstance, false, properties);
+    BpmnDiagramCheckResult result = converter.check(bpmnFile, modelInstance, properties);
     printModel(modelInstance);
     StringWriter writer = new StringWriter();
     converter.printXml(modelInstance.getDocument(), true, writer);
@@ -70,7 +70,7 @@ public class BpmnConverterTest {
         Bpmn.readModelFromStream(
             this.getClass().getClassLoader().getResourceAsStream("c8_simple.bpmn"));
     Assertions.assertThrows(
-        RuntimeException.class, () -> converter.convert(modelInstance, false, properties));
+        RuntimeException.class, () -> converter.convert(modelInstance, properties));
   }
 
   @Test
@@ -480,7 +480,7 @@ public class BpmnConverterTest {
     BpmnConverter converter = BpmnConverterFactory.getInstance().get();
     BpmnModelInstance modelInstance =
         Bpmn.readModelFromStream(getClass().getClassLoader().getResourceAsStream("delegate.bpmn"));
-    converter.convert(modelInstance, false, properties);
+    converter.convert(modelInstance, properties);
     List<DomElement> taskDefinition =
         modelInstance
             .getDocument()

--- a/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/ConverterPropertiesTest.java
+++ b/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/ConverterPropertiesTest.java
@@ -14,11 +14,11 @@ public class ConverterPropertiesTest {
   @Test
   void shouldMergeProperties() {
     DefaultConverterProperties properties = new DefaultConverterProperties();
-    properties.setAdapterJobType("adapter");
+    properties.setDefaultJobType("adapter");
     assertNull(properties.getResourceHeader());
     ConverterProperties converterProperties =
         ConverterPropertiesFactory.getInstance().merge(properties);
-    assertEquals("adapter", converterProperties.getAdapterJobType());
+    assertEquals("adapter", converterProperties.getDefaultJobType());
     assertNotNull(properties.getResourceHeader());
   }
 }

--- a/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/TestUtil.java
+++ b/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/TestUtil.java
@@ -19,7 +19,7 @@ public class TestUtil {
     BpmnModelInstance modelInstance = loadModelInstance(bpmnFile);
     BpmnConverter converter = BpmnConverterFactory.getInstance().get();
     ConverterProperties properties = ConverterPropertiesFactory.getInstance().get();
-    converter.convert(modelInstance, false, properties);
+    converter.convert(modelInstance, properties);
     return modelInstance;
   }
 

--- a/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/TestUtil.java
+++ b/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/TestUtil.java
@@ -36,10 +36,7 @@ public class TestUtil {
     properties.setPlatformVersion(targetVersion);
     BpmnDiagramCheckResult result =
         converter.check(
-            bpmnFile,
-            modelInstance,
-            false,
-            ConverterPropertiesFactory.getInstance().merge(properties));
+            bpmnFile, modelInstance, ConverterPropertiesFactory.getInstance().merge(properties));
     return result;
   }
 

--- a/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/message/MessageFactoryTest.java
+++ b/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/message/MessageFactoryTest.java
@@ -473,6 +473,23 @@ public class MessageFactoryTest {
   }
 
   @Test
+  void shouldBuildDelegateImplementationNoAdapter() {
+    String implementationType = random();
+    String binding = random();
+    Message message = delegateImplementationNoAdapter(implementationType, binding);
+    assertNotNull(message);
+    assertNotNull(message.getMessage());
+    assertNotNull(message.getSeverity());
+    assertThat(message.getMessage())
+        .isEqualTo(
+            "Delegate call of type '"
+                + implementationType
+                + "' bound to '"
+                + binding
+                + "' was reset.");
+  }
+
+  @Test
   void shouldBuildTimerExpressionMappedMessage() {
     Message message = timerExpressionMapped(result());
     assertNotNull(message);

--- a/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/message/MessageFactoryTest.java
+++ b/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/message/MessageFactoryTest.java
@@ -473,10 +473,10 @@ public class MessageFactoryTest {
   }
 
   @Test
-  void shouldBuildDelegateImplementationNoAdapter() {
+  void shouldBuildDelegateImplementationNoDefaultJobType() {
     String implementationType = random();
     String binding = random();
-    Message message = delegateImplementationNoAdapter(implementationType, binding);
+    Message message = delegateImplementationNoDefaultJobType(implementationType, binding);
     assertNotNull(message);
     assertNotNull(message.getMessage());
     assertNotNull(message.getSeverity());

--- a/backend-diagram-converter/core/src/test/resources/delegate.bpmn
+++ b/backend-diagram-converter/core/src/test/resources/delegate.bpmn
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1gbx4qr" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.19.0">
+  <bpmn:process id="GatewaysTestProcess" name="Gateways Test" isExecutable="true">
+    <bpmn:serviceTask id="serviceTask" name="Service Task" camunda:delegateExpression="${myDelegate}" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="GatewaysTestProcess">
+      <bpmndi:BPMNShape id="Activity_1ojp9xl_di" bpmnElement="serviceTask">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/backend-diagram-converter/webapp/README.md
+++ b/backend-diagram-converter/webapp/README.md
@@ -30,6 +30,7 @@ The API offers 2 methods:
     - `adapterJobType` (`String`): type of the job all service tasks formerly
       implemented as delegates or expressions should have. _(optional)_
     - `platformVersion` (`String`): version of the target platform _(optional)_
+    - `adapterEnabled` (`Boolean`): whether the adapter job type should be set in the converted diagram _(default: `true`)_
   - Headers
     - `Accept`: Either `application/json` or `text/csv`
 - Response:
@@ -48,6 +49,7 @@ The API offers 2 methods:
     - `adapterJobType` (`String`): type of the job all service tasks formerly
       implemented as delegates or expressions should have. _(optional)_
     - `platformVersion` (`String`): version of the target platform _(optional)_
+    - `adapterEnabled` (`Boolean`): whether the adapter job type should be set in the converted diagram _(default: `true`)_
 - Response:
   - `200`: Everything fine. The body contains a BPMN diagram. The header
     contains a `Content-Disposition` field that declares this as attachment and

--- a/backend-diagram-converter/webapp/src/main/java/org/camunda/community/migration/converter/webapp/BpmnConverterService.java
+++ b/backend-diagram-converter/webapp/src/main/java/org/camunda/community/migration/converter/webapp/BpmnConverterService.java
@@ -25,13 +25,13 @@ public class BpmnConverterService {
   public void convert(
       BpmnModelInstance modelInstance,
       boolean appendDocumentation,
-      String adapterJobType,
+      String defaultJobType,
       String platformVersion,
-      Boolean adapterEnabled) {
+      Boolean defaultJobTypeEnabled) {
     DefaultConverterProperties adaptedProperties = new DefaultConverterProperties();
-    adaptedProperties.setAdapterJobType(adapterJobType);
+    adaptedProperties.setDefaultJobType(defaultJobType);
     adaptedProperties.setPlatformVersion(platformVersion);
-    adaptedProperties.setAdapterEnabled(adapterEnabled);
+    adaptedProperties.setDefaultJobTypeEnabled(defaultJobTypeEnabled);
     adaptedProperties.setAppendDocumentation(appendDocumentation);
     bpmnConverter.convert(
         modelInstance, ConverterPropertiesFactory.getInstance().merge(adaptedProperties));
@@ -40,13 +40,13 @@ public class BpmnConverterService {
   public BpmnDiagramCheckResult check(
       String filename,
       BpmnModelInstance modelInstance,
-      String adapterJobType,
+      String defaultJobType,
       String platformVersion,
-      Boolean adapterEnabled) {
+      Boolean defaultJobTypeEnabled) {
     DefaultConverterProperties adaptedProperties = new DefaultConverterProperties();
-    adaptedProperties.setAdapterJobType(adapterJobType);
+    adaptedProperties.setDefaultJobType(defaultJobType);
     adaptedProperties.setPlatformVersion(platformVersion);
-    adaptedProperties.setAdapterEnabled(adapterEnabled);
+    adaptedProperties.setDefaultJobTypeEnabled(defaultJobTypeEnabled);
     return bpmnConverter.check(
         filename, modelInstance, ConverterPropertiesFactory.getInstance().merge(adaptedProperties));
   }

--- a/backend-diagram-converter/webapp/src/main/java/org/camunda/community/migration/converter/webapp/BpmnConverterService.java
+++ b/backend-diagram-converter/webapp/src/main/java/org/camunda/community/migration/converter/webapp/BpmnConverterService.java
@@ -26,10 +26,12 @@ public class BpmnConverterService {
       BpmnModelInstance modelInstance,
       boolean appendDocumentation,
       String adapterJobType,
-      String platformVersion) {
+      String platformVersion,
+      Boolean adapterEnabled) {
     DefaultConverterProperties adaptedProperties = new DefaultConverterProperties();
     adaptedProperties.setAdapterJobType(adapterJobType);
     adaptedProperties.setPlatformVersion(platformVersion);
+    adaptedProperties.setAdapterEnabled(adapterEnabled);
     bpmnConverter.convert(
         modelInstance,
         appendDocumentation,

--- a/backend-diagram-converter/webapp/src/main/java/org/camunda/community/migration/converter/webapp/BpmnConverterService.java
+++ b/backend-diagram-converter/webapp/src/main/java/org/camunda/community/migration/converter/webapp/BpmnConverterService.java
@@ -32,26 +32,23 @@ public class BpmnConverterService {
     adaptedProperties.setAdapterJobType(adapterJobType);
     adaptedProperties.setPlatformVersion(platformVersion);
     adaptedProperties.setAdapterEnabled(adapterEnabled);
+    adaptedProperties.setAppendDocumentation(appendDocumentation);
     bpmnConverter.convert(
-        modelInstance,
-        appendDocumentation,
-        ConverterPropertiesFactory.getInstance().merge(adaptedProperties));
+        modelInstance, ConverterPropertiesFactory.getInstance().merge(adaptedProperties));
   }
 
   public BpmnDiagramCheckResult check(
       String filename,
       BpmnModelInstance modelInstance,
-      boolean appendDocumentation,
       String adapterJobType,
-      String platformVersion) {
+      String platformVersion,
+      Boolean adapterEnabled) {
     DefaultConverterProperties adaptedProperties = new DefaultConverterProperties();
     adaptedProperties.setAdapterJobType(adapterJobType);
     adaptedProperties.setPlatformVersion(platformVersion);
+    adaptedProperties.setAdapterEnabled(adapterEnabled);
     return bpmnConverter.check(
-        filename,
-        modelInstance,
-        appendDocumentation,
-        ConverterPropertiesFactory.getInstance().merge(adaptedProperties));
+        filename, modelInstance, ConverterPropertiesFactory.getInstance().merge(adaptedProperties));
   }
 
   public String printXml(DomDocument document, boolean prettyPrint) {

--- a/backend-diagram-converter/webapp/src/main/java/org/camunda/community/migration/converter/webapp/ConverterController.java
+++ b/backend-diagram-converter/webapp/src/main/java/org/camunda/community/migration/converter/webapp/ConverterController.java
@@ -84,10 +84,13 @@ public class ConverterController {
       @RequestParam("file") MultipartFile bpmnFile,
       @RequestParam("appendDocumentation") boolean appendDocumentation,
       @RequestParam(value = "adapterJobType", required = false) String adapterJobType,
-      @RequestParam(value = "platformVersion", required = false) String platformVersion) {
+      @RequestParam(value = "platformVersion", required = false) String platformVersion,
+      @RequestParam(value = "adapterEnabled", required = false, defaultValue = "true")
+          Boolean adapterEnabled) {
     try (InputStream in = bpmnFile.getInputStream()) {
       BpmnModelInstance modelInstance = Bpmn.readModelFromStream(in);
-      bpmnConverter.convert(modelInstance, appendDocumentation, adapterJobType, platformVersion);
+      bpmnConverter.convert(
+          modelInstance, appendDocumentation, adapterJobType, platformVersion, adapterEnabled);
       String bpmnXml = bpmnConverter.printXml(modelInstance.getDocument(), true);
       Resource file = new ByteArrayResource(bpmnXml.getBytes());
       return ResponseEntity.ok()

--- a/backend-diagram-converter/webapp/src/main/java/org/camunda/community/migration/converter/webapp/ConverterController.java
+++ b/backend-diagram-converter/webapp/src/main/java/org/camunda/community/migration/converter/webapp/ConverterController.java
@@ -42,19 +42,19 @@ public class ConverterController {
       consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
   public ResponseEntity<?> check(
       @RequestParam("file") MultipartFile bpmnFile,
-      @RequestParam(value = "adapterJobType", required = false) String adapterJobType,
+      @RequestParam(value = "defaultJobType", required = false) String defaultJobType,
       @RequestParam(value = "platformVersion", required = false) String platformVersion,
-      @RequestParam(value = "adapterEnabled", required = false, defaultValue = "true")
-          Boolean adapterEnabled,
+      @RequestParam(value = "defaultJobTypeEnabled", required = false, defaultValue = "true")
+          Boolean defaultJobTypeEnabled,
       @RequestHeader(HttpHeaders.ACCEPT) String[] contentType) {
     try (InputStream in = bpmnFile.getInputStream()) {
       BpmnDiagramCheckResult diagramCheckResult =
           bpmnConverter.check(
               bpmnFile.getOriginalFilename(),
               Bpmn.readModelFromStream(in),
-              adapterJobType,
+              defaultJobType,
               platformVersion,
-              adapterEnabled);
+              defaultJobTypeEnabled);
       if (contentType == null
           || contentType.length == 0
           || Arrays.asList(contentType).contains(MediaType.APPLICATION_JSON_VALUE)) {
@@ -88,14 +88,18 @@ public class ConverterController {
       @RequestParam("file") MultipartFile bpmnFile,
       @RequestParam(value = "appendDocumentation", required = false, defaultValue = "false")
           Boolean appendDocumentation,
-      @RequestParam(value = "adapterJobType", required = false) String adapterJobType,
+      @RequestParam(value = "defaultJobType", required = false) String defaultJobType,
       @RequestParam(value = "platformVersion", required = false) String platformVersion,
-      @RequestParam(value = "adapterEnabled", required = false, defaultValue = "true")
-          Boolean adapterEnabled) {
+      @RequestParam(value = "defaultJobTypeEnabled", required = false, defaultValue = "true")
+          Boolean defaultJobTypeEnabled) {
     try (InputStream in = bpmnFile.getInputStream()) {
       BpmnModelInstance modelInstance = Bpmn.readModelFromStream(in);
       bpmnConverter.convert(
-          modelInstance, appendDocumentation, adapterJobType, platformVersion, adapterEnabled);
+          modelInstance,
+          appendDocumentation,
+          defaultJobType,
+          platformVersion,
+          defaultJobTypeEnabled);
       String bpmnXml = bpmnConverter.printXml(modelInstance.getDocument(), true);
       Resource file = new ByteArrayResource(bpmnXml.getBytes());
       return ResponseEntity.ok()

--- a/backend-diagram-converter/webapp/src/main/resources/static/index.html
+++ b/backend-diagram-converter/webapp/src/main/resources/static/index.html
@@ -105,11 +105,11 @@
           <input
                   class="form-check-input"
                   type="checkbox"
-                  id="adapterEnabled"
+                  id="defaultJobTypeEnabled"
                   checked
           />
-          <label for="adapterEnabled" class="form-check-label"
-          >Enable Adapter job type usage</label
+          <label for="defaultJobTypeEnabled" class="form-check-label"
+          >Enable Default job type usage</label
           >
         </div>
         <div class="mb-3">

--- a/backend-diagram-converter/webapp/src/main/resources/static/index.html
+++ b/backend-diagram-converter/webapp/src/main/resources/static/index.html
@@ -102,6 +102,17 @@
           >
         </div>
         <div class="mb-3">
+          <input
+                  class="form-check-input"
+                  type="checkbox"
+                  id="adapterEnabled"
+                  checked
+          />
+          <label for="adapterEnabled" class="form-check-label"
+          >Enable Adapter job type usage</label
+          >
+        </div>
+        <div class="mb-3">
           <button type="button" class="btn btn-primary" id="check">
             Check
           </button>

--- a/backend-diagram-converter/webapp/src/main/resources/static/lib/user-interaction.js
+++ b/backend-diagram-converter/webapp/src/main/resources/static/lib/user-interaction.js
@@ -4,7 +4,7 @@ const downloadCsv = document.getElementById("downloadCsv");
 
 const fileUpload = document.getElementById("formFile");
 const appendDocumentation = document.getElementById("appendDocumentation");
-const adapterEnabled = document.getElementById("adapterEnabled");
+const defaultJobTypeEnabled = document.getElementById("defaultJobTypeEnabled");
 
 const resultArea = document.getElementById("checkResults");
 const arrangedResultsArea = document.getElementById("arrangedResults");
@@ -74,7 +74,7 @@ const createFormData = async () => {
   }
   formData.append("file", fileUpload.files[0]);
   formData.append("appendDocumentation", appendDocumentation.checked);
-  formData.append("adapterEnabled",adapterEnabled.checked)
+  formData.append("defaultJobTypeEnabled", defaultJobTypeEnabled.checked)
   return formData;
 };
 const createFormattedResultWrapper = (file) => {

--- a/backend-diagram-converter/webapp/src/main/resources/static/lib/user-interaction.js
+++ b/backend-diagram-converter/webapp/src/main/resources/static/lib/user-interaction.js
@@ -4,6 +4,7 @@ const downloadCsv = document.getElementById("downloadCsv");
 
 const fileUpload = document.getElementById("formFile");
 const appendDocumentation = document.getElementById("appendDocumentation");
+const adapterEnabled = document.getElementById("adapterEnabled");
 
 const resultArea = document.getElementById("checkResults");
 const arrangedResultsArea = document.getElementById("arrangedResults");
@@ -73,6 +74,7 @@ const createFormData = async () => {
   }
   formData.append("file", fileUpload.files[0]);
   formData.append("appendDocumentation", appendDocumentation.checked);
+  formData.append("adapterEnabled",adapterEnabled.checked)
   return formData;
 };
 const createFormattedResultWrapper = (file) => {

--- a/backend-diagram-converter/webapp/src/test/java/org/camunda/community/migration/converter/webapp/ConverterControllerTest.java
+++ b/backend-diagram-converter/webapp/src/test/java/org/camunda/community/migration/converter/webapp/ConverterControllerTest.java
@@ -20,12 +20,15 @@ import org.camunda.bpm.model.xml.instance.DomElement;
 import org.camunda.community.migration.converter.BpmnDiagramCheckResult;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 public class ConverterControllerTest {
+  private static final Logger LOG = LoggerFactory.getLogger(ConverterControllerTest.class);
   @LocalServerPort int port;
 
   @BeforeEach
@@ -85,6 +88,7 @@ public class ConverterControllerTest {
             .getBody()
             .asByteArray();
     ByteArrayInputStream in = new ByteArrayInputStream(bpmn);
+    LOG.info("{}", new String(bpmn));
     BpmnModelInstance bpmnModelInstance = Bpmn.readModelFromStream(in);
     DomElement process = bpmnModelInstance.getDocument().getElementById("Process_11j5dku");
     assertThat(process).isNotNull();


### PR DESCRIPTION
## Description
Currently, the converter assumes that the adapter is used afterwards to execute the service tasks being implemented with gateways before.

This new feature allows to not automatically define a job type.

## Additional context
closes #264 

## Testing your changes
There are tests in place that assert the positive and negative flag behaviour

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an existing open issue)
- [x] New feature (non-breaking change which adds functionality to an extension)
- [ ] Breaking change (fix or feature that would cause existing functionality of an extension to change)
- [ ] Documentation update (changes made to an existing piece of documentation)

## Checklist:
- [x] My code adheres to the syntax used by this extension.
- [x] My pull request requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **Camunda Community Hub** documentation.
- [x] I have read the **Pull Request Process** documentation.
- [x] I have added or suggested tests to cover my changes suggested in this pull request.
- [x] All new and existing CI/CD tests passed.
- [x] I will /assign myself this issue, and add the relevant [issue labels] to it if they are not automatically generated by Probot.
- [x] I will tag @camunda-community-hub/devrel in a new comment on this issue if 30 days have passed since my pull request was opened and I have not received a response from the extension's maintainer.
