### PR TITLE
[bugfix][converter/core]: Empty error code leads to conversion error

### DIFF
--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/conversion/ErrorConversion.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/conversion/ErrorConversion.java
@@ -12,6 +12,8 @@ public class ErrorConversion extends AbstractTypedConversion<ErrorConvertible> {
 
   @Override
   protected void convertTyped(DomElement element, ErrorConvertible convertible) {
-    element.setAttribute(NamespaceUri.BPMN, "errorCode", convertible.getErrorCode());
+    if (convertible.getErrorCode() != null) {
+      element.setAttribute(NamespaceUri.BPMN, "errorCode", convertible.getErrorCode());
+    }
   }
 }

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/eventReference/ErrorVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/eventReference/ErrorVisitor.java
@@ -30,6 +30,9 @@ public class ErrorVisitor extends AbstractEventReferenceVisitor {
   @Override
   protected void postCreationVisitor(DomElementVisitorContext context) {
     String errorCode = context.getElement().getAttribute(BPMN, "errorCode");
+    if (errorCode == null) {
+      return;
+    }
     ExpressionTransformationResult expressionTransformationResult =
         ExpressionTransformer.transform(errorCode);
     if (expressionTransformationResult.getNewExpression().startsWith("=")) {

--- a/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/BpmnConverterTest.java
+++ b/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/BpmnConverterTest.java
@@ -399,9 +399,13 @@ public class BpmnConverterTest {
     assertThat(
             modelInstance.getDocument().getElementById("Error_16zktjx").getAttribute("errorCode"))
         .isEqualTo("someCode");
-    BpmnConverter converter = BpmnConverterFactory.getInstance().get();
-    StringWriter writer = new StringWriter();
-    converter.printXml(modelInstance.getDocument(), true, writer);
-    System.out.println(writer.toString());
+  }
+
+  @Test
+  void testErrorCodeMayBeNull() {
+    BpmnModelInstance modelInstance = loadAndConvert("null-error-code.bpmn");
+    assertThat(
+            modelInstance.getDocument().getElementById("Error_16zktjx").getAttribute("errorCode"))
+        .isNull();
   }
 }

--- a/backend-diagram-converter/core/src/test/resources/null-error-code.bpmn
+++ b/backend-diagram-converter/core/src/test/resources/null-error-code.bpmn
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1gbx4qr" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.12.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.19.0">
+  <bpmn:process id="TransactionTestProcess" name="Transaction Test" isExecutable="true">
+    <bpmn:startEvent id="Event_1i3htun" name="Error code conversion should be tested">
+      <bpmn:outgoing>Flow_0we8gbc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0we8gbc" sourceRef="Event_1i3htun" targetRef="Activity_1h3hatw" />
+    <bpmn:serviceTask id="Activity_1h3hatw" name="Throw error">
+      <bpmn:incoming>Flow_0we8gbc</bpmn:incoming>
+      <bpmn:outgoing>Flow_0y3k84c</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_09a497u" name="Error code conversion done">
+      <bpmn:incoming>Flow_0y3k84c</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0y3k84c" sourceRef="Activity_1h3hatw" targetRef="Event_09a497u" />
+    <bpmn:boundaryEvent id="Event_0apc6gw" name="Error thrown" attachedToRef="Activity_1h3hatw">
+      <bpmn:outgoing>Flow_03nn2dd</bpmn:outgoing>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_1ue91kl" errorRef="Error_16zktjx" />
+    </bpmn:boundaryEvent>
+    <bpmn:endEvent id="Event_1ey9c8f" name="Error handled">
+      <bpmn:incoming>Flow_03nn2dd</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_03nn2dd" sourceRef="Event_0apc6gw" targetRef="Event_1ey9c8f" />
+  </bpmn:process>
+  <bpmn:error id="Error_16zktjx" name="SomeName" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="TransactionTestProcess">
+      <bpmndi:BPMNShape id="Event_1i3htun_di" bpmnElement="Event_1i3htun">
+        <dc:Bounds x="142" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="116" y="145" width="89" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_10af0py_di" bpmnElement="Activity_1h3hatw">
+        <dc:Bounds x="230" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_09a497u_di" bpmnElement="Event_09a497u">
+        <dc:Bounds x="382" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="360" y="145" width="81" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ey9c8f_di" bpmnElement="Event_1ey9c8f">
+        <dc:Bounds x="362" y="222" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="347" y="265" width="67" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0k38m8v_di" bpmnElement="Event_0apc6gw">
+        <dc:Bounds x="272" y="142" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="260" y="185" width="61" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0we8gbc_di" bpmnElement="Flow_0we8gbc">
+        <di:waypoint x="178" y="120" />
+        <di:waypoint x="230" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0y3k84c_di" bpmnElement="Flow_0y3k84c">
+        <di:waypoint x="330" y="120" />
+        <di:waypoint x="382" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_03nn2dd_di" bpmnElement="Flow_03nn2dd">
+        <di:waypoint x="290" y="178" />
+        <di:waypoint x="290" y="240" />
+        <di:waypoint x="362" y="240" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
# Camunda Community Hub Pull Request Template

## Description
In Camunda 7, it is ok to leave out the error code in a error to create a catch-all error.

This could not be converted as it lead to a null-pointer exception.

## Additional context
closes #315 

## Testing your changes
There is a new test added asserting the correct behaviour.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an existing open issue)
- [ ] New feature (non-breaking change which adds functionality to an extension)
- [ ] Breaking change (fix or feature that would cause existing functionality of an extension to change)
- [ ] Documentation update (changes made to an existing piece of documentation)

## Checklist:
- [x] My code adheres to the syntax used by this extension.
- [x] My pull request requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **Camunda Community Hub** documentation.
- [x] I have read the **Pull Request Process** documentation.
- [x] I have added or suggested tests to cover my changes suggested in this pull request.
- [x] All new and existing CI/CD tests passed.
- [x] I will /assign myself this issue, and add the relevant [issue labels] to it if they are not automatically generated by Probot.
- [x] I will tag @camunda-community-hub/devrel in a new comment on this issue if 30 days have passed since my pull request was opened and I have not received a response from the extension's maintainer.
