### PR TITLE
bugfix: [converter/core] removed redundant message

### DIFF
--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/message/MessageFactory.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/message/MessageFactory.java
@@ -321,10 +321,6 @@ public class MessageFactory {
             .build());
   }
 
-  public static Message correlationKeyHint() {
-    return INSTANCE.staticMessage("correlation-key-hint");
-  }
-
   public static Message connectorId(String elementLocalName) {
     return INSTANCE.composeMessage(
         "connector-id",

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/AbstractFilteringVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/AbstractFilteringVisitor.java
@@ -9,7 +9,7 @@ public abstract class AbstractFilteringVisitor implements DomElementVisitor {
   protected final Logger LOG = LoggerFactory.getLogger(this.getClass());
 
   @Override
-  public void visit(DomElementVisitorContext context) {
+  public final void visit(DomElementVisitorContext context) {
     try {
       if (canVisit(context)) {
         logVisit(context);

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/eventReference/MessageVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/eventReference/MessageVisitor.java
@@ -3,7 +3,6 @@ package org.camunda.community.migration.converter.visitor.impl.eventReference;
 import org.camunda.community.migration.converter.DomElementVisitorContext;
 import org.camunda.community.migration.converter.convertible.Convertible;
 import org.camunda.community.migration.converter.convertible.MessageConvertible;
-import org.camunda.community.migration.converter.message.MessageFactory;
 import org.camunda.community.migration.converter.version.SemanticVersion;
 import org.camunda.community.migration.converter.visitor.AbstractEventReferenceVisitor;
 
@@ -16,11 +15,6 @@ public class MessageVisitor extends AbstractEventReferenceVisitor {
   @Override
   protected Convertible createConvertible(DomElementVisitorContext context) {
     return new MessageConvertible();
-  }
-
-  @Override
-  protected void postCreationVisitor(DomElementVisitorContext context) {
-    context.addMessage(MessageFactory.correlationKeyHint());
   }
 
   @Override

--- a/backend-diagram-converter/core/src/main/resources/message-templates.properties
+++ b/backend-diagram-converter/core/src/main/resources/message-templates.properties
@@ -33,9 +33,6 @@ in-all-hint.severity=INFO
 out-all-hint.message=Element 'camunda:out' with attribute 'variables="all"' is mapped to 'propagateAllChildVariables="true"'.
 out-all-hint.severity=INFO
 #
-correlation-key-hint.message=Please define a correlation key.
-correlation-key-hint.severity=TASK
-#
 connector-hint.message=Connectors will be defined as jobs in Zeebe.
 connector-hint.severity=INFO
 #

--- a/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/message/MessageFactoryTest.java
+++ b/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/message/MessageFactoryTest.java
@@ -203,13 +203,6 @@ public class MessageFactoryTest {
   }
 
   @Test
-  void shouldBuildCorrelationKeyHint() {
-    Message message = MessageFactory.correlationKeyHint();
-    assertNotNull(message);
-    assertNotNull(message.getMessage());
-  }
-
-  @Test
   void shouldBuildConnectorId() {
     Message message = MessageFactory.connectorId(random());
     assertNotNull(message);


### PR DESCRIPTION
## Description
The correlation key is a new feature for Camunda Platform 8, so any message event (except start events) will have to provide a correlation key.

There is a message in place that defines a task for this. However, this task is displayed on a the message element which is not aware of its usage (references), so filtering out to show only on non-start events is impossible.

One way to resolve this is to simply remove the message as it would be presented in the modeler anyway.

## Additional context
Closes #323 

## Testing your changes
All tests run

## Types of changes
- [x] Bug fix (non-breaking change which fixes an existing open issue)
- [ ] New feature (non-breaking change which adds functionality to an extension)
- [ ] Breaking change (fix or feature that would cause existing functionality of an extension to change)
- [ ] Documentation update (changes made to an existing piece of documentation)

## Checklist:
- [x] My code adheres to the syntax used by this extension.
- [x] My pull request requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **Camunda Community Hub** documentation.
- [x] I have read the **Pull Request Process** documentation.
- [x] I have added or suggested tests to cover my changes suggested in this pull request.
- [x] All new and existing CI/CD tests passed.
- [x] I will /assign myself this issue, and add the relevant [issue labels] to it if they are not automatically generated by Probot.
- [x] I will tag @camunda-community-hub/devrel in a new comment on this issue if 30 days have passed since my pull request was opened and I have not received a response from the extension's maintainer.
