### PR TITLE
bugfix: [converter/core] moved message from message element to event definition

### DIFF
--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/AbstractEventDefinitionVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/AbstractEventDefinitionVisitor.java
@@ -11,7 +11,11 @@ public abstract class AbstractEventDefinitionVisitor extends AbstractBpmnElement
 
   @Override
   protected final void visitBpmnElement(DomElementVisitorContext context) {
-    // do nothing
+    visitEventDefinition(context);
+  }
+
+  protected void visitEventDefinition(DomElementVisitorContext context) {
+    // can be overridden if required
   }
 
   @Override
@@ -35,8 +39,12 @@ public abstract class AbstractEventDefinitionVisitor extends AbstractBpmnElement
     return StringUtils.capitalize(element.getLocalName().split("([A-Z])")[0]);
   }
 
+  protected boolean isStartEvent(DomElement element) {
+    return element.getParentElement().getLocalName().equals("startEvent");
+  }
+
   protected boolean isNotEventSubProcessStartEvent(DomElement element) {
-    if (element.getParentElement().getLocalName().equals("startEvent")) {
+    if (isStartEvent(element)) {
       boolean triggeredByEvent =
           parseWithDefault(
               element.getParentElement().getParentElement().getAttribute(BPMN, "triggeredByEvent"),

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/activity/ReceiveTaskVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/activity/ReceiveTaskVisitor.java
@@ -5,6 +5,7 @@ import static org.camunda.community.migration.converter.NamespaceUri.*;
 import org.camunda.community.migration.converter.DomElementVisitorContext;
 import org.camunda.community.migration.converter.convertible.Convertible;
 import org.camunda.community.migration.converter.convertible.ReceiveTaskConvertible;
+import org.camunda.community.migration.converter.message.MessageFactory;
 import org.camunda.community.migration.converter.version.SemanticVersion;
 import org.camunda.community.migration.converter.visitor.AbstractActivityVisitor;
 
@@ -17,6 +18,11 @@ public class ReceiveTaskVisitor extends AbstractActivityVisitor {
   @Override
   protected Convertible createConvertible(DomElementVisitorContext context) {
     return new ReceiveTaskConvertible();
+  }
+
+  @Override
+  protected void postCreationVisitor(DomElementVisitorContext context) {
+    context.addMessage(MessageFactory.correlationKeyHint());
   }
 
   @Override

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/eventDefinition/MessageEventDefinitionVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/eventDefinition/MessageEventDefinitionVisitor.java
@@ -1,6 +1,7 @@
 package org.camunda.community.migration.converter.visitor.impl.eventDefinition;
 
 import org.camunda.community.migration.converter.DomElementVisitorContext;
+import org.camunda.community.migration.converter.message.MessageFactory;
 import org.camunda.community.migration.converter.version.SemanticVersion;
 import org.camunda.community.migration.converter.visitor.AbstractEventDefinitionVisitor;
 
@@ -13,5 +14,12 @@ public class MessageEventDefinitionVisitor extends AbstractEventDefinitionVisito
   @Override
   protected SemanticVersion availableFrom(DomElementVisitorContext context) {
     return SemanticVersion._8_0_0;
+  }
+
+  @Override
+  protected void visitEventDefinition(DomElementVisitorContext context) {
+    if (!isStartEvent(context.getElement())) {
+      context.addMessage(MessageFactory.correlationKeyHint());
+    }
   }
 }

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/eventDefinition/SignalEventDefinitionVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/eventDefinition/SignalEventDefinitionVisitor.java
@@ -14,13 +14,10 @@ public class SignalEventDefinitionVisitor extends AbstractEventDefinitionVisitor
 
   @Override
   protected SemanticVersion availableFrom(DomElementVisitorContext context) {
-    if (isStartEvent(context) && isNotEventSubProcessStartEvent(context.getElement())) {
+    if (isStartEvent(context.getElement())
+        && isNotEventSubProcessStartEvent(context.getElement())) {
       return SemanticVersion._8_2_0;
     }
     return null;
-  }
-
-  private boolean isStartEvent(DomElementVisitorContext context) {
-    return context.getElement().getParentElement().getLocalName().equals("startEvent");
   }
 }

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/eventReference/MessageVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/eventReference/MessageVisitor.java
@@ -3,7 +3,6 @@ package org.camunda.community.migration.converter.visitor.impl.eventReference;
 import org.camunda.community.migration.converter.DomElementVisitorContext;
 import org.camunda.community.migration.converter.convertible.Convertible;
 import org.camunda.community.migration.converter.convertible.MessageConvertible;
-import org.camunda.community.migration.converter.message.MessageFactory;
 import org.camunda.community.migration.converter.version.SemanticVersion;
 import org.camunda.community.migration.converter.visitor.AbstractEventReferenceVisitor;
 
@@ -16,11 +15,6 @@ public class MessageVisitor extends AbstractEventReferenceVisitor {
   @Override
   protected Convertible createConvertible(DomElementVisitorContext context) {
     return new MessageConvertible();
-  }
-
-  @Override
-  protected void postCreationVisitor(DomElementVisitorContext context) {
-    context.addMessage(MessageFactory.correlationKeyHint());
   }
 
   @Override

--- a/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/BpmnConverterTest.java
+++ b/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/BpmnConverterTest.java
@@ -413,6 +413,21 @@ public class BpmnConverterTest {
         .isNull();
   }
 
+  @Test
+  void testMessageStartEventShouldNotShowCorrelationKeyTask() {
+    BpmnDiagramCheckResult result = loadAndCheck("message-example.bpmn");
+    assertThat(result.getResult("ExampleWantedStartEvent"))
+        .isNotNull()
+        .extracting(BpmnElementCheckResult::getMessages)
+        .asList()
+        .isEmpty();
+    assertThat(result.getResult("Receive1Task"))
+        .isNotNull()
+        .extracting(BpmnElementCheckResult::getMessages)
+        .asList()
+        .hasSize(1);
+  }
+
   @ParameterizedTest
   @CsvSource(
       value = {

--- a/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/BpmnElementSupportTest.java
+++ b/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/BpmnElementSupportTest.java
@@ -5,11 +5,14 @@ import static org.assertj.core.api.Assertions.*;
 import static org.camunda.community.migration.converter.TestUtil.*;
 import static org.junit.jupiter.api.DynamicTest.*;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.camunda.community.migration.converter.BpmnDiagramCheckResult.BpmnElementCheckMessage;
 import org.camunda.community.migration.converter.BpmnDiagramCheckResult.BpmnElementCheckResult;
+import org.camunda.community.migration.converter.BpmnDiagramCheckResult.Severity;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.api.function.Executable;
@@ -58,6 +61,7 @@ public class BpmnElementSupportTest {
       assertThat(result.getResult(elementId))
           .isNotNull()
           .extracting(BpmnElementCheckResult::getMessages)
+          .extracting(this::findWarnings)
           .asList()
           .isEmpty();
     };
@@ -71,6 +75,7 @@ public class BpmnElementSupportTest {
       assertThat(result.getResult(elementId))
           .isNotNull()
           .extracting(BpmnElementCheckResult::getMessages)
+          .extracting(this::findWarnings)
           .matches(l -> l.size() == 1, "Has one entry")
           .extracting(l -> l.get(0))
           .extracting(BpmnElementCheckMessage::getMessage)
@@ -81,6 +86,12 @@ public class BpmnElementSupportTest {
                   + ConverterPropertiesFactory.getInstance().get().getPlatformVersion()
                   + "'. Please review.");
     };
+  }
+
+  private List<BpmnElementCheckMessage> findWarnings(List<BpmnElementCheckMessage> messages) {
+    return messages.stream()
+        .filter(m -> m.getSeverity().equals(Severity.WARNING))
+        .collect(Collectors.toList());
   }
 
   @TestFactory


### PR DESCRIPTION
## Description
The correlation key is a new feature for Camunda Platform 8, so any message event (except start events) will have to provide a correlation key.

There is a message in place that defines a task for this. However, this task is displayed on a the message element which is not aware of its usage (references), so filtering out to show only on non-start events is impossible.

Another way to resolve this is to move the messages displayed from the message element to the message event definition plus receive task element.

## Additional context
Closes #323 

## Testing your changes
A new test ensures that the start event does not display a message to provide a correlation key

## Types of changes
- [x] Bug fix (non-breaking change which fixes an existing open issue)
- [ ] New feature (non-breaking change which adds functionality to an extension)
- [ ] Breaking change (fix or feature that would cause existing functionality of an extension to change)
- [ ] Documentation update (changes made to an existing piece of documentation)

## Checklist:
- [x] My code adheres to the syntax used by this extension.
- [x] My pull request requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **Camunda Community Hub** documentation.
- [x] I have read the **Pull Request Process** documentation.
- [x] I have added or suggested tests to cover my changes suggested in this pull request.
- [x] All new and existing CI/CD tests passed.
- [x] I will /assign myself this issue, and add the relevant [issue labels] to it if they are not automatically generated by Probot.
- [x] I will tag @camunda-community-hub/devrel in a new comment on this issue if 30 days have passed since my pull request was opened and I have not received a response from the extension's maintainer.
