### PR TITLE
bugfix: [converter/core] Differentiate between condition expression implementations

### DIFF
--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/message/MessageFactory.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/message/MessageFactory.java
@@ -176,6 +176,14 @@ public class MessageFactory {
             .build());
   }
 
+  public static Message conditionExpression(String juelExpression, String feelExpression) {
+    return INSTANCE.composeMessage(
+        "condition-expression",
+        ContextBuilder.builder()
+            .context(expressionTransformationResult(juelExpression, feelExpression))
+            .build());
+  }
+
   public static Message conditionExpressionExecution(
       ExpressionTransformationResult transformationResult) {
     return INSTANCE.composeMessage(
@@ -536,6 +544,14 @@ public class MessageFactory {
         .build();
   }
 
+  private static Map<String, String> expressionTransformationResult(
+      String juelExpression, String feelExpression) {
+    return ContextBuilder.builder()
+        .entry("oldExpression", juelExpression)
+        .entry("newExpression", feelExpression)
+        .build();
+  }
+
   private static Map<String, String> supportedAttributePrefix(
       String attributeLocalName, String elementLocalName) {
     return ContextBuilder.builder()
@@ -659,6 +675,18 @@ public class MessageFactory {
             .entry("eventType", eventType)
             .entry("semanticVersion", semanticVersion)
             .build());
+  }
+
+  public static Message resourceOnConditionalFlow(String resource) {
+    return INSTANCE.composeMessage(
+        "resource-on-conditional-flow",
+        ContextBuilder.builder().entry("resource", resource).build());
+  }
+
+  public static Message scriptOnConditionalFlow(String language, String script) {
+    return INSTANCE.composeMessage(
+        "script-on-conditional-flow",
+        ContextBuilder.builder().entry("language", language).entry("script", script).build());
   }
 
   private Message composeMessage(String templateName, Map<String, String> context) {

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/message/MessageFactory.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/message/MessageFactory.java
@@ -2,7 +2,6 @@ package org.camunda.community.migration.converter.message;
 
 import java.util.Collections;
 import java.util.Map;
-import org.camunda.community.migration.converter.expression.ExpressionTransformationResult;
 
 public class MessageFactory {
   private static final MessageFactory INSTANCE = new MessageFactory();
@@ -42,137 +41,135 @@ public class MessageFactory {
             .build());
   }
 
-  public static Message completionCondition(ExpressionTransformationResult transformationResult) {
+  public static Message completionCondition(String juelExpression, String feelExpression) {
     return INSTANCE.composeMessage(
         "completion-condition",
         ContextBuilder.builder()
-            .context(expressionTransformationResult(transformationResult))
+            .context(expressionTransformationResult(juelExpression, feelExpression))
             .build());
   }
 
-  public static Message completionConditionExecution(
-      ExpressionTransformationResult transformationResult) {
+  public static Message completionConditionExecution(String juelExpression, String feelExpression) {
     return INSTANCE.composeMessage(
         "completion-condition-execution",
         ContextBuilder.builder()
-            .context(expressionTransformationResult(transformationResult))
+            .context(expressionTransformationResult(juelExpression, feelExpression))
             .build());
   }
 
-  public static Message completionConditionMethod(
-      ExpressionTransformationResult transformationResult) {
+  public static Message completionConditionMethod(String juelExpression, String feelExpression) {
     return INSTANCE.composeMessage(
         "completion-condition-method",
         ContextBuilder.builder()
-            .context(expressionTransformationResult(transformationResult))
+            .context(expressionTransformationResult(juelExpression, feelExpression))
             .build());
   }
 
-  public static Message candidateGroups(ExpressionTransformationResult transformationResult) {
+  public static Message candidateGroups(String juelExpression, String feelExpression) {
     return INSTANCE.composeMessage(
         "candidate-groups",
         ContextBuilder.builder()
             .context(
-                supportedAttributeExpression("candidateGroups", "userTask", transformationResult))
+                supportedAttributeExpression(
+                    "candidateGroups", "userTask", juelExpression, feelExpression))
             .build());
   }
 
   public static Message calledElement(
       String attributeLocalName,
       String elementLocalName,
-      ExpressionTransformationResult transformationResult) {
+      String juelExpression,
+      String feelExpression) {
     return INSTANCE.composeMessage(
         "called-element",
         ContextBuilder.builder()
             .context(
                 supportedAttributeExpression(
-                    attributeLocalName, elementLocalName, transformationResult))
+                    attributeLocalName, elementLocalName, juelExpression, feelExpression))
             .build());
   }
 
   public static Message decisionRef(
       String attributeLocalName,
       String elementLocalName,
-      ExpressionTransformationResult transformationResult) {
+      String juelExpression,
+      String feelExpression) {
     return INSTANCE.composeMessage(
         "decision-ref",
         ContextBuilder.builder()
             .context(
                 supportedAttributeExpression(
-                    attributeLocalName, elementLocalName, transformationResult))
+                    attributeLocalName, elementLocalName, juelExpression, feelExpression))
             .build());
   }
 
   public static Message formRef(
       String attributeLocalName,
       String elementLocalName,
-      ExpressionTransformationResult transformationResult) {
+      String juelExpression,
+      String feelExpression) {
     return INSTANCE.composeMessage(
         "form-ref",
         ContextBuilder.builder()
             .context(
                 supportedAttributeExpression(
-                    attributeLocalName, elementLocalName, transformationResult))
+                    attributeLocalName, elementLocalName, juelExpression, feelExpression))
             .build());
   }
 
   public static Message collection(
       String attributeLocalName,
       String elementLocalName,
-      ExpressionTransformationResult transformationResult) {
+      String juelExpression,
+      String feelExpression) {
     return INSTANCE.composeMessage(
         "collection",
         ContextBuilder.builder()
             .context(
                 supportedAttributeExpression(
-                    attributeLocalName, elementLocalName, transformationResult))
+                    attributeLocalName, elementLocalName, juelExpression, feelExpression))
             .build());
   }
 
   public static Message collectionExecution(
       String attributeLocalName,
       String elementLocalName,
-      ExpressionTransformationResult transformationResult) {
+      String juelExpression,
+      String feelExpression) {
     return INSTANCE.composeMessage(
         "collection-execution",
         ContextBuilder.builder()
             .context(
                 supportedAttributeExpression(
-                    attributeLocalName, elementLocalName, transformationResult))
+                    attributeLocalName, elementLocalName, juelExpression, feelExpression))
             .build());
   }
 
   public static Message collectionMethod(
       String attributeLocalName,
       String elementLocalName,
-      ExpressionTransformationResult transformationResult) {
+      String juelExpression,
+      String feelExpression) {
     return INSTANCE.composeMessage(
         "collection-method",
         ContextBuilder.builder()
             .context(
                 supportedAttributeExpression(
-                    attributeLocalName, elementLocalName, transformationResult))
+                    attributeLocalName, elementLocalName, juelExpression, feelExpression))
             .build());
   }
 
   public static Message assignee(
       String attributeLocalName,
       String elementLocalName,
-      ExpressionTransformationResult transformationResult) {
+      String juelExpression,
+      String feelExpression) {
     return INSTANCE.composeMessage(
         "assignee",
         ContextBuilder.builder()
             .context(
                 supportedAttributeExpression(
-                    attributeLocalName, elementLocalName, transformationResult))
-            .build());
-  }
-
-  public static Message conditionExpression(ExpressionTransformationResult transformationResult) {
-    return INSTANCE.composeMessage(
-        "condition-expression",
-        ContextBuilder.builder()
-            .context(expressionTransformationResult(transformationResult))
+                    attributeLocalName, elementLocalName, juelExpression, feelExpression))
             .build());
   }
 
@@ -184,21 +181,28 @@ public class MessageFactory {
             .build());
   }
 
-  public static Message conditionExpressionExecution(
-      ExpressionTransformationResult transformationResult) {
+  public static Message conditionExpressionFeel(
+      String oldFeelExpression, String newFeelExpression) {
     return INSTANCE.composeMessage(
-        "condition-expression-execution",
+        "condition-expression-feel",
         ContextBuilder.builder()
-            .context(expressionTransformationResult(transformationResult))
+            .context(expressionTransformationResult(oldFeelExpression, newFeelExpression))
             .build());
   }
 
-  public static Message conditionExpressionMethod(
-      ExpressionTransformationResult transformationResult) {
+  public static Message conditionExpressionExecution(String juelExpression, String feelExpression) {
+    return INSTANCE.composeMessage(
+        "condition-expression-execution",
+        ContextBuilder.builder()
+            .context(expressionTransformationResult(juelExpression, feelExpression))
+            .build());
+  }
+
+  public static Message conditionExpressionMethod(String juelExpression, String feelExpression) {
     return INSTANCE.composeMessage(
         "condition-expression-method",
         ContextBuilder.builder()
-            .context(expressionTransformationResult(transformationResult))
+            .context(expressionTransformationResult(juelExpression, feelExpression))
             .build());
   }
 
@@ -213,41 +217,35 @@ public class MessageFactory {
   }
 
   public static Message inputOutputParameter(
-      String elementLocalName,
-      String parameterName,
-      ExpressionTransformationResult transformationResult) {
+      String elementLocalName, String parameterName, String juelExpression, String feelExpression) {
     return INSTANCE.composeMessage(
         "input-output-parameter",
         ContextBuilder.builder()
             .entry("parameterName", parameterName)
             .context(elementTransformedPrefix(elementLocalName))
-            .context(expressionTransformationResult(transformationResult))
+            .context(expressionTransformationResult(juelExpression, feelExpression))
             .build());
   }
 
   public static Message inputOutputParameterExecution(
-      String elementLocalName,
-      String parameterName,
-      ExpressionTransformationResult transformationResult) {
+      String elementLocalName, String parameterName, String juelExpression, String feelExpression) {
     return INSTANCE.composeMessage(
         "input-output-parameter-execution",
         ContextBuilder.builder()
             .entry("parameterName", parameterName)
             .context(elementTransformedPrefix(elementLocalName))
-            .context(expressionTransformationResult(transformationResult))
+            .context(expressionTransformationResult(juelExpression, feelExpression))
             .build());
   }
 
   public static Message inputOutputParameterMethod(
-      String elementLocalName,
-      String parameterName,
-      ExpressionTransformationResult transformationResult) {
+      String elementLocalName, String parameterName, String juelExpression, String feelExpression) {
     return INSTANCE.composeMessage(
         "input-output-parameter-method",
         ContextBuilder.builder()
             .entry("parameterName", parameterName)
             .context(elementTransformedPrefix(elementLocalName))
-            .context(expressionTransformationResult(transformationResult))
+            .context(expressionTransformationResult(juelExpression, feelExpression))
             .build());
   }
 
@@ -529,18 +527,11 @@ public class MessageFactory {
   private static Map<String, String> supportedAttributeExpression(
       String attributeLocalName,
       String elementLocalName,
-      ExpressionTransformationResult transformationResult) {
+      String juelExpression,
+      String feelExpression) {
     return ContextBuilder.builder()
         .context(supportedAttributePrefix(attributeLocalName, elementLocalName))
-        .context(expressionTransformationResult(transformationResult))
-        .build();
-  }
-
-  private static Map<String, String> expressionTransformationResult(
-      ExpressionTransformationResult transformationResult) {
-    return ContextBuilder.builder()
-        .entry("oldExpression", transformationResult.getJuelExpression())
-        .entry("newExpression", transformationResult.getFeelExpression())
+        .context(expressionTransformationResult(juelExpression, feelExpression))
         .build();
   }
 
@@ -624,28 +615,32 @@ public class MessageFactory {
     return INSTANCE.staticMessage("result-variable-internal-script");
   }
 
-  public static Message candidateUsers(ExpressionTransformationResult transformationResult) {
+  public static Message candidateUsers(String juelExpression, String feelExpression) {
     return INSTANCE.composeMessage(
         "candidate-users",
         ContextBuilder.builder()
             .context(
-                supportedAttributeExpression("candidateUsers", "userTask", transformationResult))
+                supportedAttributeExpression(
+                    "candidateUsers", "userTask", juelExpression, feelExpression))
             .build());
   }
 
-  public static Message followUpDate(ExpressionTransformationResult transformationResult) {
+  public static Message followUpDate(String juelExpression, String feelExpression) {
     return INSTANCE.composeMessage(
         "follow-up-date",
         ContextBuilder.builder()
-            .context(supportedAttributeExpression("followUpDate", "userTask", transformationResult))
+            .context(
+                supportedAttributeExpression(
+                    "followUpDate", "userTask", juelExpression, feelExpression))
             .build());
   }
 
-  public static Message dueDate(ExpressionTransformationResult transformationResult) {
+  public static Message dueDate(String juelExpression, String feelExpression) {
     return INSTANCE.composeMessage(
         "due-date",
         ContextBuilder.builder()
-            .context(supportedAttributeExpression("dueDate", "userTask", transformationResult))
+            .context(
+                supportedAttributeExpression("dueDate", "userTask", juelExpression, feelExpression))
             .build());
   }
 
@@ -657,11 +652,11 @@ public class MessageFactory {
     return INSTANCE.staticMessage("escalation-code-no-expression");
   }
 
-  public static Message timerExpressionMapped(ExpressionTransformationResult transformationResult) {
+  public static Message timerExpressionMapped(String juelExpression, String feelExpression) {
     return INSTANCE.composeMessage(
         "timer-expression-mapped",
         ContextBuilder.builder()
-            .context(expressionTransformationResult(transformationResult))
+            .context(expressionTransformationResult(juelExpression, feelExpression))
             .build());
   }
 

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/AbstractTimerExpressionVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/AbstractTimerExpressionVisitor.java
@@ -19,7 +19,9 @@ public abstract class AbstractTimerExpressionVisitor extends AbstractBpmnElement
         con -> setNewExpression(con, transformationResult.getFeelExpression()));
     if (!Objects.equals(
         transformationResult.getFeelExpression(), transformationResult.getJuelExpression())) {
-      context.addMessage(MessageFactory.timerExpressionMapped(transformationResult));
+      context.addMessage(
+          MessageFactory.timerExpressionMapped(
+              transformationResult.getJuelExpression(), transformationResult.getFeelExpression()));
     }
   }
 

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/CompletionConditionVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/CompletionConditionVisitor.java
@@ -29,11 +29,17 @@ public class CompletionConditionVisitor extends AbstractBpmnElementVisitor {
                 .setCompletionCondition(transformationResult.getFeelExpression()));
     Message message;
     if (transformationResult.hasExecution()) {
-      message = MessageFactory.completionConditionExecution(transformationResult);
+      message =
+          MessageFactory.completionConditionExecution(
+              transformationResult.getJuelExpression(), transformationResult.getFeelExpression());
     } else if (transformationResult.hasMethodInvocation()) {
-      message = MessageFactory.completionConditionMethod(transformationResult);
+      message =
+          MessageFactory.completionConditionMethod(
+              transformationResult.getJuelExpression(), transformationResult.getFeelExpression());
     } else {
-      message = MessageFactory.completionCondition(transformationResult);
+      message =
+          MessageFactory.completionCondition(
+              transformationResult.getJuelExpression(), transformationResult.getFeelExpression());
     }
     context.addMessage(message);
   }

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/ConditionExpressionVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/ConditionExpressionVisitor.java
@@ -1,9 +1,11 @@
 package org.camunda.community.migration.converter.visitor.impl;
 
+import static org.camunda.community.migration.converter.NamespaceUri.*;
+
 import java.util.Arrays;
+import org.apache.commons.lang3.StringUtils;
 import org.camunda.bpm.model.xml.instance.DomElement;
 import org.camunda.community.migration.converter.DomElementVisitorContext;
-import org.camunda.community.migration.converter.NamespaceUri;
 import org.camunda.community.migration.converter.convertible.SequenceFlowConvertible;
 import org.camunda.community.migration.converter.expression.ExpressionTransformationResult;
 import org.camunda.community.migration.converter.expression.ExpressionTransformer;
@@ -23,8 +25,7 @@ public class ConditionExpressionVisitor extends AbstractBpmnElementVisitor {
   }
 
   private boolean isConditionalFlow(DomElementVisitorContext context) {
-    String sourceRef =
-        context.getElement().getParentElement().getAttribute(NamespaceUri.BPMN, "sourceRef");
+    String sourceRef = context.getElement().getParentElement().getAttribute(BPMN, "sourceRef");
     if (sourceRef == null) {
       return false;
     }
@@ -36,7 +37,7 @@ public class ConditionExpressionVisitor extends AbstractBpmnElementVisitor {
   }
 
   private boolean isGateway(DomElement element) {
-    return element.getNamespaceURI().equals(NamespaceUri.BPMN)
+    return element.getNamespaceURI().equals(BPMN)
         && Arrays.asList(
                 ExclusiveGatewayVisitor.ELEMENT_LOCAL_NAME,
                 InclusiveGatewayVisitor.ELEMENT_LOCAL_NAME,
@@ -51,6 +52,38 @@ public class ConditionExpressionVisitor extends AbstractBpmnElementVisitor {
 
   @Override
   protected void visitBpmnElement(DomElementVisitorContext context) {
+    String language = context.getElement().getAttribute(BPMN, "language");
+    if (StringUtils.isBlank(language)) {
+      handleJuelExpression(context);
+    } else {
+      handleLanguage(context, language);
+    }
+  }
+
+  private void handleLanguage(DomElementVisitorContext context, String language) {
+    String resource = context.getElement().getAttribute(CAMUNDA, "resource");
+    if (StringUtils.isNotBlank(resource)) {
+      context.addMessage(MessageFactory.resourceOnConditionalFlow(resource));
+      return;
+    }
+    if ("feel".equalsIgnoreCase(language)) {
+      String oldExpression = context.getElement().getTextContent();
+      String newExpression = "=" + oldExpression;
+      context.addConversion(
+          SequenceFlowConvertible.class, c -> c.setConditionExpression(newExpression));
+      context.addMessage(MessageFactory.conditionExpression(oldExpression, newExpression));
+      return;
+    }
+    context.addMessage(
+        MessageFactory.scriptOnConditionalFlow(language, context.getElement().getTextContent()));
+  }
+
+  @Override
+  protected Message cannotBeConvertedMessage(DomElementVisitorContext context) {
+    return MessageFactory.conditionalFlow();
+  }
+
+  private void handleJuelExpression(DomElementVisitorContext context) {
     String expression = context.getElement().getTextContent();
     ExpressionTransformationResult transformationResult =
         ExpressionTransformer.transform(expression);
@@ -64,10 +97,5 @@ public class ConditionExpressionVisitor extends AbstractBpmnElementVisitor {
     } else {
       context.addMessage(MessageFactory.conditionExpression(transformationResult));
     }
-  }
-
-  @Override
-  protected Message cannotBeConvertedMessage(DomElementVisitorContext context) {
-    return MessageFactory.conditionalFlow();
   }
 }

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/ConditionExpressionVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/ConditionExpressionVisitor.java
@@ -67,11 +67,7 @@ public class ConditionExpressionVisitor extends AbstractBpmnElementVisitor {
       return;
     }
     if ("feel".equalsIgnoreCase(language)) {
-      String oldExpression = context.getElement().getTextContent();
-      String newExpression = "=" + oldExpression;
-      context.addConversion(
-          SequenceFlowConvertible.class, c -> c.setConditionExpression(newExpression));
-      context.addMessage(MessageFactory.conditionExpression(oldExpression, newExpression));
+      handleFeelExpression(context);
       return;
     }
     context.addMessage(
@@ -83,6 +79,14 @@ public class ConditionExpressionVisitor extends AbstractBpmnElementVisitor {
     return MessageFactory.conditionalFlow();
   }
 
+  private void handleFeelExpression(DomElementVisitorContext context) {
+    String oldExpression = context.getElement().getTextContent();
+    String newExpression = "=" + oldExpression;
+    context.addConversion(
+        SequenceFlowConvertible.class, c -> c.setConditionExpression(newExpression));
+    context.addMessage(MessageFactory.conditionExpressionFeel(oldExpression, newExpression));
+  }
+
   private void handleJuelExpression(DomElementVisitorContext context) {
     String expression = context.getElement().getTextContent();
     ExpressionTransformationResult transformationResult =
@@ -91,11 +95,17 @@ public class ConditionExpressionVisitor extends AbstractBpmnElementVisitor {
         SequenceFlowConvertible.class,
         conversion -> conversion.setConditionExpression(transformationResult.getFeelExpression()));
     if (transformationResult.hasExecution()) {
-      context.addMessage(MessageFactory.conditionExpressionExecution(transformationResult));
+      context.addMessage(
+          MessageFactory.conditionExpressionExecution(
+              transformationResult.getJuelExpression(), transformationResult.getFeelExpression()));
     } else if (transformationResult.hasMethodInvocation()) {
-      context.addMessage(MessageFactory.conditionExpressionMethod(transformationResult));
+      context.addMessage(
+          MessageFactory.conditionExpressionMethod(
+              transformationResult.getJuelExpression(), transformationResult.getFeelExpression()));
     } else {
-      context.addMessage(MessageFactory.conditionExpression(transformationResult));
+      context.addMessage(
+          MessageFactory.conditionExpression(
+              transformationResult.getJuelExpression(), transformationResult.getFeelExpression()));
     }
   }
 }

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/activity/CallActivityVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/activity/CallActivityVisitor.java
@@ -37,7 +37,11 @@ public class CallActivityVisitor extends AbstractActivityVisitor {
                   .getZeebeCalledElement()
                   .setProcessId(transformationResult.getFeelExpression()));
       context.addMessage(
-          MessageFactory.calledElement(CALLED_ELEMENT, localName(), transformationResult));
+          MessageFactory.calledElement(
+              CALLED_ELEMENT,
+              localName(),
+              transformationResult.getJuelExpression(),
+              transformationResult.getFeelExpression()));
     }
   }
 

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/attribute/AssigneeVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/attribute/AssigneeVisitor.java
@@ -26,6 +26,9 @@ public class AssigneeVisitor extends AbstractSupportedAttributeVisitor {
                 .getZeebeAssignmentDefinition()
                 .setAssignee(transformationResult.getFeelExpression()));
     return MessageFactory.assignee(
-        attributeLocalName(), context.getElement().getLocalName(), transformationResult);
+        attributeLocalName(),
+        context.getElement().getLocalName(),
+        transformationResult.getJuelExpression(),
+        transformationResult.getFeelExpression());
   }
 }

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/attribute/CandidateGroupsVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/attribute/CandidateGroupsVisitor.java
@@ -17,13 +17,15 @@ public class CandidateGroupsVisitor extends AbstractSupportedAttributeVisitor {
 
   @Override
   protected Message visitSupportedAttribute(DomElementVisitorContext context, String attribute) {
-    ExpressionTransformationResult candidateGroups = ExpressionTransformer.transform(attribute);
+    ExpressionTransformationResult transformationResult =
+        ExpressionTransformer.transform(attribute);
     context.addConversion(
         UserTaskConvertible.class,
         userTaskConversion ->
             userTaskConversion
                 .getZeebeAssignmentDefinition()
-                .setCandidateGroups(candidateGroups.getFeelExpression()));
-    return MessageFactory.candidateGroups(candidateGroups);
+                .setCandidateGroups(transformationResult.getFeelExpression()));
+    return MessageFactory.candidateGroups(
+        transformationResult.getJuelExpression(), transformationResult.getFeelExpression());
   }
 }

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/attribute/CandidateUsersVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/attribute/CandidateUsersVisitor.java
@@ -20,6 +20,7 @@ public class CandidateUsersVisitor extends AbstractSupportedAttributeVisitor {
     context.addConversion(
         UserTaskConvertible.class,
         convertible -> convertible.getZeebeAssignmentDefinition().setCandidateUsers(attribute));
-    return MessageFactory.candidateUsers(candidateUsers);
+    return MessageFactory.candidateUsers(
+        candidateUsers.getJuelExpression(), candidateUsers.getFeelExpression());
   }
 }

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/attribute/CollectionVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/attribute/CollectionVisitor.java
@@ -33,15 +33,24 @@ public class CollectionVisitor extends AbstractSupportedAttributeVisitor {
     if (transformationResult.hasExecution()) {
       message =
           MessageFactory.collectionExecution(
-              attributeLocalName(), context.getElement().getLocalName(), transformationResult);
+              attributeLocalName(),
+              context.getElement().getLocalName(),
+              transformationResult.getJuelExpression(),
+              transformationResult.getFeelExpression());
     } else if (transformationResult.hasMethodInvocation()) {
       message =
           MessageFactory.collectionMethod(
-              attributeLocalName(), context.getElement().getLocalName(), transformationResult);
+              attributeLocalName(),
+              context.getElement().getLocalName(),
+              transformationResult.getJuelExpression(),
+              transformationResult.getFeelExpression());
     } else {
       message =
           MessageFactory.collection(
-              attributeLocalName(), context.getElement().getLocalName(), transformationResult);
+              attributeLocalName(),
+              context.getElement().getLocalName(),
+              transformationResult.getJuelExpression(),
+              transformationResult.getFeelExpression());
     }
     return message;
   }

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/attribute/DecisionRefVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/attribute/DecisionRefVisitor.java
@@ -25,6 +25,9 @@ public class DecisionRefVisitor extends AbstractSupportedAttributeVisitor {
                 .getZeebeCalledDecision()
                 .setDecisionId(transformationResult.getFeelExpression()));
     return MessageFactory.decisionRef(
-        attributeLocalName(), context.getElement().getLocalName(), transformationResult);
+        attributeLocalName(),
+        context.getElement().getLocalName(),
+        transformationResult.getJuelExpression(),
+        transformationResult.getFeelExpression());
   }
 }

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/attribute/DueDateVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/attribute/DueDateVisitor.java
@@ -20,6 +20,6 @@ public class DueDateVisitor extends AbstractSupportedAttributeVisitor {
     context.addConversion(
         UserTaskConvertible.class,
         conv -> conv.getZeebeTaskSchedule().setDueDate(dueDate.getFeelExpression()));
-    return MessageFactory.dueDate(dueDate);
+    return MessageFactory.dueDate(dueDate.getJuelExpression(), dueDate.getFeelExpression());
   }
 }

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/attribute/FollowUpDateVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/attribute/FollowUpDateVisitor.java
@@ -20,6 +20,7 @@ public class FollowUpDateVisitor extends AbstractSupportedAttributeVisitor {
     context.addConversion(
         UserTaskConvertible.class,
         conv -> conv.getZeebeTaskSchedule().setFollowUpDate(followUpDate.getFeelExpression()));
-    return MessageFactory.followUpDate(followUpDate);
+    return MessageFactory.followUpDate(
+        followUpDate.getJuelExpression(), followUpDate.getFeelExpression());
   }
 }

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/attribute/ResourceVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/attribute/ResourceVisitor.java
@@ -1,5 +1,8 @@
 package org.camunda.community.migration.converter.visitor.impl.attribute;
 
+import static org.camunda.community.migration.converter.NamespaceUri.*;
+
+import org.camunda.bpm.model.xml.instance.DomElement;
 import org.camunda.community.migration.converter.DomElementVisitorContext;
 import org.camunda.community.migration.converter.convertible.AbstractDataMapperConvertible;
 import org.camunda.community.migration.converter.message.Message;
@@ -15,6 +18,9 @@ public class ResourceVisitor extends AbstractSupportedAttributeVisitor {
 
   @Override
   protected Message visitSupportedAttribute(DomElementVisitorContext context, String attribute) {
+    if (isSequenceFlow(context.getElement())) {
+      return null;
+    }
     context.addConversion(
         AbstractDataMapperConvertible.class,
         convertible ->
@@ -23,5 +29,13 @@ public class ResourceVisitor extends AbstractSupportedAttributeVisitor {
         attributeLocalName(),
         context.getElement().getLocalName(),
         context.getProperties().getResourceHeader());
+  }
+
+  private boolean isSequenceFlow(DomElement element) {
+    if (element == null) {
+      return false;
+    }
+    return element.getLocalName().equals("sequenceFlow") && element.getNamespaceURI().equals(BPMN)
+        || isSequenceFlow(element.getParentElement());
   }
 }

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/attribute/UserTaskFormRefVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/attribute/UserTaskFormRefVisitor.java
@@ -25,7 +25,10 @@ public class UserTaskFormRefVisitor extends AbstractSupportedAttributeVisitor {
                 .getZeebeFormDefinition()
                 .setFormKey(transformationResult.getFeelExpression()));
     return MessageFactory.formRef(
-        attributeLocalName(), context.getElement().getLocalName(), transformationResult);
+        attributeLocalName(),
+        context.getElement().getLocalName(),
+        transformationResult.getJuelExpression(),
+        transformationResult.getFeelExpression());
   }
 
   @Override

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/element/InOutVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/element/InOutVisitor.java
@@ -76,7 +76,11 @@ public abstract class InOutVisitor extends AbstractCamundaElementVisitor {
                   getDirection(context.getElement()),
                   transformationResult.getFeelExpression(),
                   target));
-      return MessageFactory.inputOutputParameter(localName(), target, transformationResult);
+      return MessageFactory.inputOutputParameter(
+          localName(),
+          target,
+          transformationResult.getJuelExpression(),
+          transformationResult.getFeelExpression());
     }
   }
 

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/element/InputOutputParameterVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/element/InputOutputParameterVisitor.java
@@ -38,12 +38,25 @@ public abstract class InputOutputParameterVisitor extends AbstractCamundaElement
     Message resultMessage;
     if (transformationResult.hasExecution()) {
       resultMessage =
-          MessageFactory.inputOutputParameterExecution(localName(), name, transformationResult);
+          MessageFactory.inputOutputParameterExecution(
+              localName(),
+              name,
+              transformationResult.getJuelExpression(),
+              transformationResult.getFeelExpression());
     } else if (transformationResult.hasMethodInvocation()) {
       resultMessage =
-          MessageFactory.inputOutputParameterMethod(localName(), name, transformationResult);
+          MessageFactory.inputOutputParameterMethod(
+              localName(),
+              name,
+              transformationResult.getJuelExpression(),
+              transformationResult.getFeelExpression());
     } else {
-      resultMessage = MessageFactory.inputOutputParameter(localName(), name, transformationResult);
+      resultMessage =
+          MessageFactory.inputOutputParameter(
+              localName(),
+              name,
+              transformationResult.getJuelExpression(),
+              transformationResult.getFeelExpression());
     }
     return resultMessage;
   }

--- a/backend-diagram-converter/core/src/main/resources/message-templates.properties
+++ b/backend-diagram-converter/core/src/main/resources/message-templates.properties
@@ -59,6 +59,9 @@ completion-condition-method.severity=TASK
 condition-expression.message=Condition expression: {{ templates.expression-transformation-result }}
 condition-expression.severity=REVIEW
 #
+condition-expression-feel.message=FEEL Condition expression: {{ templates.expression-transformation-result }} Check for custom FEEL functions as they are not supported by Zeebe.
+condition-expression-feel.severity=REVIEW
+#
 condition-expression-execution.message=Condition expression: {{ templates.expression-transformation-hint }} {{ templates.execution-not-available }}
 condition-expression-execution.severity=TASK
 #

--- a/backend-diagram-converter/core/src/main/resources/message-templates.properties
+++ b/backend-diagram-converter/core/src/main/resources/message-templates.properties
@@ -215,6 +215,13 @@ timer-expression-not-supported.severity=WARNING
 timer-expression-mapped.message=Timer expression was transformed: {{ templates.expression-transformation-result }}
 timer-expression-mapped.severity=REVIEW
 #
+resource-on-conditional-flow.message=Please translate the content from '{{ resource }}' to a valid FEEL expression.
+resource-on-conditional-flow.severity=TASK
+#
+#
+script-on-conditional-flow.message=Please translate the {{ language }} script from '{{ script }}' to a valid FEEL expression.
+script-on-conditional-flow.severity=TASK
+#
 # BPMN attribute
 #
 script-format.message=Script format '{{ scriptFormat }}' was set to header '{{ headerName }}'. Please review.

--- a/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/BpmnConverterTest.java
+++ b/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/BpmnConverterTest.java
@@ -520,6 +520,7 @@ public class BpmnConverterTest {
         .extracting(BpmnElementCheckResult::getMessages)
         .matches(l -> !l.isEmpty())
         .extracting(l -> l.get(0).getMessage())
-        .isEqualTo("Condition expression: Please review transformed expression: 'x=4' -> '=x=4'.");
+        .isEqualTo(
+            "FEEL Condition expression: Please review transformed expression: 'x=4' -> '=x=4'. Check for custom FEEL functions as they are not supported by Zeebe.");
   }
 }

--- a/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/BpmnConverterTest.java
+++ b/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/BpmnConverterTest.java
@@ -490,4 +490,36 @@ public class BpmnConverterTest {
             .getChildElementsByNameNs(ZEEBE, "taskDefinition");
     assertThat(taskDefinition).isEmpty();
   }
+
+  @Test
+  void testConditionalSequenceFlowWithLanguages() {
+    BpmnDiagramCheckResult result = loadAndCheck("conditional-flow-many-languages.bpmn");
+    assertThat(result.getResult("JuelSequenceFlow"))
+        .isNotNull()
+        .extracting(BpmnElementCheckResult::getMessages)
+        .matches(l -> !l.isEmpty())
+        .extracting(l -> l.get(0).getMessage())
+        .isEqualTo(
+            "Condition expression: Please review transformed expression: '${x == 1}' -> '=x = 1'.");
+    assertThat(result.getResult("ExternalScriptSequenceFlow"))
+        .isNotNull()
+        .extracting(BpmnElementCheckResult::getMessages)
+        .matches(l -> !l.isEmpty())
+        .extracting(l -> l.get(0).getMessage())
+        .isEqualTo(
+            "Please translate the content from 'some-resource.js' to a valid FEEL expression.");
+    assertThat(result.getResult("InternalScriptSequenceFlow"))
+        .isNotNull()
+        .extracting(BpmnElementCheckResult::getMessages)
+        .matches(l -> !l.isEmpty())
+        .extracting(l -> l.get(0).getMessage())
+        .isEqualTo(
+            "Please translate the javascript script from 'return x === 3;' to a valid FEEL expression.");
+    assertThat(result.getResult("FeelScriptSequenceFlow"))
+        .isNotNull()
+        .extracting(BpmnElementCheckResult::getMessages)
+        .matches(l -> !l.isEmpty())
+        .extracting(l -> l.get(0).getMessage())
+        .isEqualTo("Condition expression: Please review transformed expression: 'x=4' -> '=x=4'.");
+  }
 }

--- a/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/message/MessageFactoryTest.java
+++ b/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/message/MessageFactoryTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.*;
 import static org.camunda.community.migration.converter.message.MessageFactory.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import org.camunda.community.migration.converter.expression.ExpressionTransformationResult;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
 
@@ -13,10 +12,6 @@ public class MessageFactoryTest {
 
   private static String random() {
     return RandomStringUtils.randomAlphabetic(10);
-  }
-
-  private static ExpressionTransformationResult result() {
-    return new ExpressionTransformationResult("${test}", "=test");
   }
 
   @Test
@@ -49,7 +44,7 @@ public class MessageFactoryTest {
 
   @Test
   void shouldBuildCollection() {
-    Message message = MessageFactory.collection(random(), random(), result());
+    Message message = MessageFactory.collection(random(), random(), random(), random());
     assertNotNull(message);
     assertNotNull(message.getMessage());
   }
@@ -98,7 +93,7 @@ public class MessageFactoryTest {
 
   @Test
   void shouldBuildAssignee() {
-    Message message = MessageFactory.assignee(random(), random(), result());
+    Message message = MessageFactory.assignee(random(), random(), random(), random());
     assertNotNull(message);
     assertNotNull(message.getMessage());
   }
@@ -112,7 +107,7 @@ public class MessageFactoryTest {
 
   @Test
   void shouldBuildFormRef() {
-    Message message = MessageFactory.formRef(random(), random(), result());
+    Message message = MessageFactory.formRef(random(), random(), random(), random());
     assertNotNull(message);
     assertNotNull(message.getMessage());
   }
@@ -140,14 +135,14 @@ public class MessageFactoryTest {
 
   @Test
   void shouldBuildConditionExpression() {
-    Message message = MessageFactory.conditionExpression(result());
+    Message message = MessageFactory.conditionExpression(random(), random());
     assertNotNull(message);
     assertNotNull(message.getMessage());
   }
 
   @Test
   void shouldBuildInputOutputParameter() {
-    Message message = MessageFactory.inputOutputParameter(random(), random(), result());
+    Message message = MessageFactory.inputOutputParameter(random(), random(), random(), random());
     assertNotNull(message);
     assertNotNull(message.getMessage());
   }
@@ -321,7 +316,7 @@ public class MessageFactoryTest {
 
   @Test
   void shouldBuildCandidateGroups() {
-    Message message = MessageFactory.candidateGroups(result());
+    Message message = MessageFactory.candidateGroups(random(), random());
     assertNotNull(message);
     assertNotNull(message.getMessage());
   }
@@ -335,14 +330,14 @@ public class MessageFactoryTest {
 
   @Test
   void shouldBuildCalledElement() {
-    Message message = MessageFactory.calledElement(random(), random(), result());
+    Message message = MessageFactory.calledElement(random(), random(), random(), random());
     assertNotNull(message);
     assertNotNull(message.getMessage());
   }
 
   @Test
   void shouldBuildDecisionRef() {
-    Message message = MessageFactory.decisionRef(random(), random(), result());
+    Message message = MessageFactory.decisionRef(random(), random(), random(), random());
     assertNotNull(message);
     assertNotNull(message.getMessage());
   }
@@ -366,7 +361,7 @@ public class MessageFactoryTest {
 
   @Test
   void shouldBuildCompletionCondition() {
-    Message message = MessageFactory.completionCondition(result());
+    Message message = MessageFactory.completionCondition(random(), random());
     assertNotNull(message);
     assertNotNull(message.getMessage());
   }
@@ -423,35 +418,47 @@ public class MessageFactoryTest {
 
   @Test
   void shouldBuildCandidateUsers() {
-    Message message = MessageFactory.candidateUsers(result());
+    String juelExpression = random();
+    String feelExpression = random();
+    Message message = MessageFactory.candidateUsers(juelExpression, feelExpression);
     assertNotNull(message);
     assertNotNull(message.getMessage());
     assertNotNull(message.getSeverity());
     assertThat(message.getMessage())
         .isEqualTo(
-            "Attribute 'candidateUsers' on 'userTask' was mapped. Please review transformed expression: '${test}' -> '=test'.");
+            String.format(
+                "Attribute 'candidateUsers' on 'userTask' was mapped. Please review transformed expression: '%s' -> '%s'.",
+                juelExpression, feelExpression));
   }
 
   @Test
   void shouldBuildDueDate() {
-    Message message = MessageFactory.dueDate(result());
+    String juelExpression = random();
+    String feelExpression = random();
+    Message message = MessageFactory.dueDate(juelExpression, feelExpression);
     assertNotNull(message);
     assertNotNull(message.getMessage());
     assertNotNull(message.getSeverity());
     assertThat(message.getMessage())
         .isEqualTo(
-            "Attribute 'dueDate' on 'userTask' was mapped. Please review transformed expression: '${test}' -> '=test'.");
+            String.format(
+                "Attribute 'dueDate' on 'userTask' was mapped. Please review transformed expression: '%s' -> '%s'.",
+                juelExpression, feelExpression));
   }
 
   @Test
   void shouldBuildFollowUpDate() {
-    Message message = MessageFactory.followUpDate(result());
+    String juelExpression = random();
+    String feelExpression = random();
+    Message message = MessageFactory.followUpDate(juelExpression, feelExpression);
     assertNotNull(message);
     assertNotNull(message.getMessage());
     assertNotNull(message.getSeverity());
     assertThat(message.getMessage())
         .isEqualTo(
-            "Attribute 'followUpDate' on 'userTask' was mapped. Please review transformed expression: '${test}' -> '=test'.");
+            String.format(
+                "Attribute 'followUpDate' on 'userTask' was mapped. Please review transformed expression: '%s' -> '%s'.",
+                juelExpression, feelExpression));
   }
 
   @Test
@@ -491,13 +498,17 @@ public class MessageFactoryTest {
 
   @Test
   void shouldBuildTimerExpressionMappedMessage() {
-    Message message = timerExpressionMapped(result());
+    String juelExpression = random();
+    String feelExpression = random();
+    Message message = timerExpressionMapped(juelExpression, feelExpression);
     assertNotNull(message);
     assertNotNull(message.getMessage());
     assertNotNull(message.getSeverity());
     assertThat(message.getMessage())
         .isEqualTo(
-            "Timer expression was transformed: Please review transformed expression: '${test}' -> '=test'.");
+            String.format(
+                "Timer expression was transformed: Please review transformed expression: '%s' -> '%s'.",
+                juelExpression, feelExpression));
   }
 
   @Test
@@ -547,5 +558,19 @@ public class MessageFactoryTest {
         .isEqualTo(
             "Please translate the %s script from '%s' to a valid FEEL expression.",
             language, script);
+  }
+
+  @Test
+  void shouldBuildConditionExpressionFeel() {
+    String oldExpression = random();
+    String newExpression = random();
+    Message message = conditionExpressionFeel(oldExpression, newExpression);
+    assertNotNull(message);
+    assertNotNull(message.getMessage());
+    assertNotNull(message.getSeverity());
+    assertThat(message.getMessage())
+        .isEqualTo(
+            "FEEL Condition expression: Please review transformed expression: '%s' -> '%s'. Check for custom FEEL functions as they are not supported by Zeebe.",
+            oldExpression, newExpression);
   }
 }

--- a/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/message/MessageFactoryTest.java
+++ b/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/message/MessageFactoryTest.java
@@ -523,4 +523,29 @@ public class MessageFactoryTest {
                 + semanticVersion
                 + "'.");
   }
+
+  @Test
+  void shouldBuildResourceOnConditionalFlow() {
+    String resource = random();
+    Message message = resourceOnConditionalFlow(resource);
+    assertNotNull(message);
+    assertNotNull(message.getMessage());
+    assertNotNull(message.getSeverity());
+    assertThat(message.getMessage())
+        .isEqualTo("Please translate the content from '%s' to a valid FEEL expression.", resource);
+  }
+
+  @Test
+  void shouldBuildScriptOnConditionalFlow() {
+    String script = random();
+    String language = random();
+    Message message = scriptOnConditionalFlow(language, script);
+    assertNotNull(message);
+    assertNotNull(message.getMessage());
+    assertNotNull(message.getSeverity());
+    assertThat(message.getMessage())
+        .isEqualTo(
+            "Please translate the %s script from '%s' to a valid FEEL expression.",
+            language, script);
+  }
 }

--- a/backend-diagram-converter/core/src/test/resources/conditional-flow-many-languages.bpmn
+++ b/backend-diagram-converter/core/src/test/resources/conditional-flow-many-languages.bpmn
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1d61i45" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.13.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.19.0">
+  <bpmn:process id="Process_128vk7d" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1j2c8xw</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:exclusiveGateway id="XGateway" name="x?">
+      <bpmn:incoming>Flow_1j2c8xw</bpmn:incoming>
+      <bpmn:outgoing>JuelSequenceFlow</bpmn:outgoing>
+      <bpmn:outgoing>ExternalScriptSequenceFlow</bpmn:outgoing>
+      <bpmn:outgoing>InternalScriptSequenceFlow</bpmn:outgoing>
+      <bpmn:outgoing>FeelScriptSequenceFlow</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1j2c8xw" sourceRef="StartEvent_1" targetRef="XGateway" />
+    <bpmn:sequenceFlow id="JuelSequenceFlow" name="juel" sourceRef="XGateway" targetRef="Event_1mgxry6">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${x == 1}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="ExternalScriptSequenceFlow" name="external script" sourceRef="XGateway" targetRef="Event_0my32x1">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" language="javascript" camunda:resource="some-resource.js" />
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="InternalScriptSequenceFlow" name="internal script" sourceRef="XGateway" targetRef="Event_0k8b59x">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" language="javascript">return x === 3;</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:endEvent id="Event_1mgxry6">
+      <bpmn:incoming>JuelSequenceFlow</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_0my32x1">
+      <bpmn:incoming>ExternalScriptSequenceFlow</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_0k8b59x">
+      <bpmn:incoming>InternalScriptSequenceFlow</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="FeelScriptSequenceFlow" name="feel script" sourceRef="XGateway" targetRef="Event_13vwla9">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" language="feel">x=4</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:endEvent id="Event_13vwla9">
+      <bpmn:incoming>FeelScriptSequenceFlow</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_128vk7d">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="109" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1l73f0m_di" bpmnElement="XGateway" isMarkerVisible="true">
+        <dc:Bounds x="265" y="102" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="284" y="78" width="12" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1mgxry6_di" bpmnElement="Event_1mgxry6">
+        <dc:Bounds x="532" y="109" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0my32x1_di" bpmnElement="Event_0my32x1">
+        <dc:Bounds x="532" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0k8b59x_di" bpmnElement="Event_0k8b59x">
+        <dc:Bounds x="532" y="332" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_13vwla9_di" bpmnElement="Event_13vwla9">
+        <dc:Bounds x="532" y="442" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1j2c8xw_di" bpmnElement="Flow_1j2c8xw">
+        <di:waypoint x="215" y="127" />
+        <di:waypoint x="265" y="127" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1p7kneh_di" bpmnElement="JuelSequenceFlow">
+        <di:waypoint x="315" y="127" />
+        <di:waypoint x="532" y="127" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="350" y="109" width="17" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_03ubz4o_di" bpmnElement="ExternalScriptSequenceFlow">
+        <di:waypoint x="290" y="152" />
+        <di:waypoint x="290" y="240" />
+        <di:waypoint x="532" y="240" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="345" y="223" width="69" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0kqic4q_di" bpmnElement="InternalScriptSequenceFlow">
+        <di:waypoint x="290" y="152" />
+        <di:waypoint x="290" y="350" />
+        <di:waypoint x="532" y="350" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="347" y="333" width="66" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0nbpstm_di" bpmnElement="FeelScriptSequenceFlow">
+        <di:waypoint x="290" y="152" />
+        <di:waypoint x="290" y="460" />
+        <di:waypoint x="532" y="460" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="356" y="443" width="48" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Description
Although uncommon, it is possible to define a condition expression as script and even externalize this script.

The converter did not respect this until now.

## Additional context
closes #319 

## Testing your changes
There is a new test in place to assert the conversion behaviour on the different implementation types as well as tests for the new messages

## Types of changes
- [x] Bug fix (non-breaking change which fixes an existing open issue)
- [ ] New feature (non-breaking change which adds functionality to an extension)
- [ ] Breaking change (fix or feature that would cause existing functionality of an extension to change)
- [ ] Documentation update (changes made to an existing piece of documentation)

## Checklist:
- [x] My code adheres to the syntax used by this extension.
- [x] My pull request requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **Camunda Community Hub** documentation.
- [x] I have read the **Pull Request Process** documentation.
- [x] I have added or suggested tests to cover my changes suggested in this pull request.
- [x] All new and existing CI/CD tests passed.
- [x] I will /assign myself this issue, and add the relevant [issue labels] to it if they are not automatically generated by Probot.
- [x] I will tag @camunda-community-hub/devrel in a new comment on this issue if 30 days have passed since my pull request was opened and I have not received a response from the extension's maintainer.
