### PR TITLE
fix(converter/core): A business rule using an expression with result variable threw exception

### DIFF
--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/activity/BusinessRuleTaskVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/activity/BusinessRuleTaskVisitor.java
@@ -1,6 +1,5 @@
 package org.camunda.community.migration.converter.visitor.impl.activity;
 
-import org.camunda.bpm.model.xml.instance.DomElement;
 import org.camunda.community.migration.converter.DomElementVisitorContext;
 import org.camunda.community.migration.converter.NamespaceUri;
 import org.camunda.community.migration.converter.convertible.BusinessRuleTaskConvertible;
@@ -17,7 +16,7 @@ public class BusinessRuleTaskVisitor extends AbstractActivityVisitor {
 
   @Override
   protected Convertible createConvertible(DomElementVisitorContext context) {
-    if (isDmnImplementation(context.getElement(), context)) {
+    if (isDmnImplementation(context)) {
       return new BusinessRuleTaskConvertible();
     } else {
       return new ServiceTaskConvertible();
@@ -29,7 +28,7 @@ public class BusinessRuleTaskVisitor extends AbstractActivityVisitor {
     return SemanticVersion._8_0_0;
   }
 
-  private boolean isDmnImplementation(DomElement element, DomElementVisitorContext context) {
-    return element.getAttribute(NamespaceUri.CAMUNDA, "decisionRef") != null;
+  public static boolean isDmnImplementation(DomElementVisitorContext context) {
+    return context.getElement().getAttribute(NamespaceUri.CAMUNDA, "decisionRef") != null;
   }
 }

--- a/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/attribute/ResultVariableVisitor.java
+++ b/backend-diagram-converter/core/src/main/java/org/camunda/community/migration/converter/visitor/impl/attribute/ResultVariableVisitor.java
@@ -7,9 +7,15 @@ import org.camunda.community.migration.converter.convertible.ScriptTaskConvertib
 import org.camunda.community.migration.converter.message.Message;
 import org.camunda.community.migration.converter.message.MessageFactory;
 import org.camunda.community.migration.converter.visitor.AbstractSupportedAttributeVisitor;
+import org.camunda.community.migration.converter.visitor.impl.activity.BusinessRuleTaskVisitor;
 import org.camunda.community.migration.converter.visitor.impl.activity.ScriptTaskVisitor;
 
 public abstract class ResultVariableVisitor extends AbstractSupportedAttributeVisitor {
+
+  public static boolean isBusinessRuleTask(DomElementVisitorContext context) {
+    return context.getElement().getLocalName().equals("businessRuleTask")
+        && BusinessRuleTaskVisitor.isDmnImplementation(context);
+  }
 
   @Override
   public String attributeLocalName() {
@@ -35,7 +41,7 @@ public abstract class ResultVariableVisitor extends AbstractSupportedAttributeVi
 
     @Override
     protected boolean canVisitResultVariable(DomElementVisitorContext context) {
-      return context.getElement().getLocalName().equals("businessRuleTask");
+      return ResultVariableVisitor.isBusinessRuleTask(context);
     }
   }
 
@@ -56,7 +62,7 @@ public abstract class ResultVariableVisitor extends AbstractSupportedAttributeVi
 
     @Override
     protected boolean canVisitResultVariable(DomElementVisitorContext context) {
-      return (!context.getElement().getLocalName().equals("businessRuleTask"))
+      return !ResultVariableVisitor.isBusinessRuleTask(context)
           && !ScriptTaskVisitor.canBeInternalScript(context);
     }
   }

--- a/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/BpmnConverterTest.java
+++ b/backend-diagram-converter/core/src/test/java/org/camunda/community/migration/converter/BpmnConverterTest.java
@@ -37,7 +37,8 @@ public class BpmnConverterTest {
         "internal-script.bpmn",
         "collaboration.bpmn",
         "empty-input-parameter.bpmn",
-        "flexible-timer-event.bpmn"
+        "flexible-timer-event.bpmn",
+        "business-rule-task-as-expression.bpmn"
       })
   public void shouldConvert(String bpmnFile) {
     BpmnConverter converter = BpmnConverterFactory.getInstance().get();

--- a/backend-diagram-converter/core/src/test/resources/business-rule-task-as-expression.bpmn
+++ b/backend-diagram-converter/core/src/test/resources/business-rule-task-as-expression.bpmn
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1x62qzq" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.15.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.19.0">
+  <bpmn:process id="businessRuleTaskAsExpression" isExecutable="true" camunda:historyTimeToLive="180">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_19gavdu</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_19gavdu" sourceRef="StartEvent_1" targetRef="Activity_0z2soja" />
+    <bpmn:businessRuleTask id="Activity_0z2soja" name="I am weird" camunda:expression="${y}" camunda:resultVariable="x">
+      <bpmn:incoming>Flow_19gavdu</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ziz7xf</bpmn:outgoing>
+    </bpmn:businessRuleTask>
+    <bpmn:endEvent id="Event_1321kij">
+      <bpmn:incoming>Flow_0ziz7xf</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0ziz7xf" sourceRef="Activity_0z2soja" targetRef="Event_1321kij" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="businessRuleTaskAsExpression">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_02iwbz2_di" bpmnElement="Activity_0z2soja">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1321kij_di" bpmnElement="Event_1321kij">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_19gavdu_di" bpmnElement="Flow_19gavdu">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ziz7xf_di" bpmnElement="Flow_0ziz7xf">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Description
Mapping the result variable of a task was until now only depending on whether the task itself is a business rule task.

This worked in all cases except when a business rule task is implemented as expression with result variable.

In this case, it is treated as service task which leads to a problem with the convertible type.

## Additional context
The bug came in as notification from the hosted instance.

## Testing your changes
There is a new test in place to assert that this constellation is now covered properly

## Types of changes
- [x] Bug fix (non-breaking change which fixes an existing open issue)
- [ ] New feature (non-breaking change which adds functionality to an extension)
- [ ] Breaking change (fix or feature that would cause existing functionality of an extension to change)
- [ ] Documentation update (changes made to an existing piece of documentation)

## Checklist:
- [x] My code adheres to the syntax used by this extension.
- [x] My pull request requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **Camunda Community Hub** documentation.
- [x] I have read the **Pull Request Process** documentation.
- [x] I have added or suggested tests to cover my changes suggested in this pull request.
- [x] All new and existing CI/CD tests passed.
- [x] I will /assign myself this issue, and add the relevant [issue labels] to it if they are not automatically generated by Probot.
- [x] I will tag @camunda-community-hub/devrel in a new comment on this issue if 30 days have passed since my pull request was opened and I have not received a response from the extension's maintainer.
